### PR TITLE
feat(ui): redesign navbar with terminal aesthetic and keyboard shortcuts

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -2,6 +2,7 @@ import { ScrambleText } from "@/components/scramble-text"
 import { PostsList } from "@/components/posts-list"
 import { getPosts } from "@/lib/blog"
 import { Metadata } from "next"
+import { Search, Command, ArrowUp, ArrowDown } from "lucide-react"
 
 const posts = getPosts().sort(
   (a, b) =>
@@ -11,33 +12,76 @@ const posts = getPosts().sort(
 export default async function BlogPage() {
   return (
     <main className="animate-fade-in-up relative">
-      <h1 className="text-4xl font-semibold mb-8 text-white underline decoration-blue-400 decoration-4">
-        <ScrambleText className="font-semibold leading-none" text="Blog" />
-      </h1>
+      {/* Terminal Window Header */}
+      <div className="border border-gray-800/60 bg-[#161616] mb-8">
+        {/* Terminal Bar */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-800/60 bg-[#1a1a1a]">
+          <div className="flex items-center gap-2">
+            <div className="flex gap-1.5">
+              <span className="w-3 h-3 rounded-full bg-red-500/80" />
+              <span className="w-3 h-3 rounded-full bg-yellow-500/80" />
+              <span className="w-3 h-3 rounded-full bg-green-500/80" />
+            </div>
+            <span className="ml-3 text-xs text-gray-500 font-mono">~/blog</span>
+          </div>
+          <div className="text-xs text-gray-600 font-mono">
+            {posts.length} artigos
+          </div>
+        </div>
 
-      <p className="hidden sm:block text-sm text-gray-400 mb-8">
-        pressione{" "}
-        <kbd className="px-1 py-0.5 text-xs border border-gray-700">
-          /
-        </kbd>{" "}
-        para buscar • use{" "}
-        <kbd className="px-1 py-0.5 text-xs border border-gray-700">
-          ctrl / ⌘ j
-        </kbd>{" "}
-        e{" "}
-        <kbd className="px-1 py-0.5 text-xs border border-gray-700">
-          ctrl / ⌘ k
-        </kbd>{" "}
-        ou{" "}
-        <kbd className="px-1 py-0.5 text-xs border border-gray-700">
-          ↑
-        </kbd>{" "}
-        e{" "}
-        <kbd className="px-1 py-0.5 text-xs border border-gray-700">
-          ↓
-        </kbd>{" "}
-        para navegar
-      </p>
+        {/* Content */}
+        <div className="p-6">
+          <h1 className="text-3xl sm:text-4xl font-bold text-white mb-4">
+            <ScrambleText className="font-bold leading-none" text="Blog" />
+          </h1>
+
+          <p className="text-gray-400 font-mono text-sm mb-6">
+            <span className="text-emerald-400">❯</span>
+            <span className="text-gray-500 ml-2">cat</span>
+            <span className="text-white ml-2">description.md</span>
+          </p>
+
+          <p className="text-gray-300 leading-relaxed pl-5 border-l-2 border-gray-800">
+            Artigos sobre <span className="text-blue-400">engenharia de software</span>,
+            <span className="text-blue-400"> cloud native</span>,
+            <span className="text-blue-400"> Go</span> e
+            <span className="text-blue-400"> sistemas distribuídos</span>.
+          </p>
+        </div>
+      </div>
+
+      {/* Keyboard Shortcuts Info */}
+      <div className="hidden sm:flex items-center gap-6 mb-8 p-4 border border-gray-800/60 bg-[#161616]">
+        <div className="flex items-center gap-2 text-gray-500 text-xs">
+          <Command className="w-3 h-3" />
+          <span>Atalhos:</span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <kbd className="px-2 py-1 bg-gray-800/50 border border-gray-700 text-gray-400 font-mono text-xs">
+            /
+          </kbd>
+          <span className="text-gray-500 text-xs">buscar</span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <kbd className="px-2 py-1 bg-gray-800/50 border border-gray-700 text-gray-400 font-mono text-xs">
+            ↑
+          </kbd>
+          <kbd className="px-2 py-1 bg-gray-800/50 border border-gray-700 text-gray-400 font-mono text-xs">
+            ↓
+          </kbd>
+          <span className="text-gray-500 text-xs">navegar</span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <kbd className="px-2 py-1 bg-gray-800/50 border border-gray-700 text-gray-400 font-mono text-xs">
+            enter
+          </kbd>
+          <span className="text-gray-500 text-xs">abrir</span>
+        </div>
+      </div>
+
       <PostsList posts={posts} />
     </main>
   )

--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -1,16 +1,27 @@
 import { ScrambleText } from '@/components/scramble-text'
-import { Item } from '@/components/section-list'
-import { SectionListNotGrouped } from '@/components/section-list-not-grouped'
 import { Metadata } from 'next'
-import React from 'react'
+import { Briefcase, GraduationCap, Code2, ArrowUpRight, MapPin, Calendar, ExternalLink } from 'lucide-react'
+import Link from 'next/link'
 
-const workItems: Item[] = [
+type WorkItem = {
+  title: string
+  role: string
+  period: string
+  description: string
+  href: string
+  technologies?: string[]
+  current?: boolean
+}
+
+const workItems: WorkItem[] = [
   {
     title: "All Net Educação",
     role: "Educador & Mentor Técnico",
     period: "jan 2025 - atual",
     description: "Liderança técnica e formação de talentos em Backend (Go) e Arquitetura de Software. Responsável por traduzir desafios reais de mercado em projetos práticos, focando em Clean Code, escalabilidade e boas práticas de desenvolvimento moderno.",
     href: "https://allneteducacao.com.br/",
+    technologies: ["Go", "Clean Architecture", "Mentoria"],
+    current: true,
   },
   {
     title: "ZinwellCorp - TB Smart",
@@ -18,6 +29,7 @@ const workItems: Item[] = [
     period: "jan 2024 - jan 2025",
     description: "Arquitetura e desenvolvimento de sistemas de missão crítica em Go e Clean Architecture. Implementação de infraestrutura como código (Terraform) e orquestração de containers (Kubernetes/EKS), otimizando pipelines CI/CD para operações de alto volume.",
     href: "https://www.tbsmart.com.br/",
+    technologies: ["Go", "Kubernetes", "Terraform", "AWS"],
   },
   {
     title: "ZinwellCorp",
@@ -25,20 +37,181 @@ const workItems: Item[] = [
     period: "jul 2023 - jan 2024",
     description: "Garantia de qualidade e eficiência operacional através de testes rigorosos, elaboração de relatórios técnicos e suporte estratégico a clientes em tecnologias de hardware e software.",
     href: "https://www.tbsmart.com.br/",
+    technologies: ["QA", "Documentação", "Suporte"],
   },
 ]
 
-function page() {
+const skills = [
+  { category: "Languages", items: ["Go", "TypeScript", "Python", "Bash"] },
+  { category: "Cloud & Infra", items: ["AWS", "Kubernetes", "Docker", "Terraform"] },
+  { category: "Databases", items: ["PostgreSQL", "Redis", "Cassandra", "MongoDB"] },
+  { category: "Practices", items: ["Clean Architecture", "CI/CD", "Observability", "SRE"] },
+]
+
+function SobrePage() {
   return (
-    <div>
-      <h1 className="text-4xl font-bold mb-8 text-white underline decoration-blue-400 decoration-4">
-        <ScrambleText className="font-semibold leading-none" text="Sobre mim" />
-      </h1>
-      <p className="leading-relaxed animate-fade-in-up">
-       Engenheiro de Software & SRE. Foco em Cloud Native, Go e Kubernetes. Especialista em projetar sistemas de alto volume onde disponibilidade e performance são inegociáveis. Unindo arquitetura limpa à automação de infraestrutura, entrego soluções que escalam e mentoro times que buscam excelência técnica.
-      </p>
-      <div className="mt-10">
-        <SectionListNotGrouped title="Work" items={workItems} />
+    <div className="animate-fade-in-up">
+      {/* Terminal Window - About Header */}
+      <div className="border border-gray-800/60 bg-[#161616] mb-8">
+        {/* Terminal Bar */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-800/60 bg-[#1a1a1a]">
+          <div className="flex items-center gap-2">
+            <div className="flex gap-1.5">
+              <span className="w-3 h-3 rounded-full bg-red-500/80" />
+              <span className="w-3 h-3 rounded-full bg-yellow-500/80" />
+              <span className="w-3 h-3 rounded-full bg-green-500/80" />
+            </div>
+            <span className="ml-3 text-xs text-gray-500 font-mono">~/sobre</span>
+          </div>
+          <div className="flex items-center gap-2 text-xs text-gray-600 font-mono">
+            <MapPin className="w-3 h-3" />
+            São Paulo, BR
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="p-6">
+          <h1 className="text-3xl sm:text-4xl font-bold text-white mb-4">
+            <ScrambleText className="font-bold leading-none" text="Sobre mim" />
+          </h1>
+
+          {/* Command Line Bio */}
+          <div className="font-mono text-sm space-y-3 text-gray-400 mb-6">
+            <div className="flex items-start gap-2">
+              <span className="text-emerald-400 select-none">❯</span>
+              <span className="text-gray-500">whoami</span>
+            </div>
+            <div className="pl-5 text-gray-300 leading-relaxed">
+              Engenheiro de Software & SRE
+            </div>
+
+            <div className="flex items-start gap-2 mt-4">
+              <span className="text-emerald-400 select-none">❯</span>
+              <span className="text-gray-500">cat</span>
+              <span className="text-white">bio.md</span>
+            </div>
+            <div className="pl-5 text-gray-300 leading-relaxed border-l-2 border-gray-800">
+              Foco em <span className="text-blue-400">Cloud Native</span>,
+              <span className="text-blue-400"> Go</span> e
+              <span className="text-blue-400"> Kubernetes</span>.
+              Especialista em projetar sistemas de alto volume onde disponibilidade e performance são inegociáveis.
+              Unindo arquitetura limpa à automação de infraestrutura, entrego soluções que escalam e mentoro times que buscam excelência técnica.
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Skills Grid - JSON Style */}
+      <div className="border border-gray-800/60 bg-[#161616] mb-8">
+        <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-800/60 bg-[#1a1a1a]">
+          <Code2 className="w-4 h-4 text-gray-500" />
+          <span className="text-xs text-gray-500 font-mono">skills.json</span>
+        </div>
+
+        <div className="p-5 font-mono text-sm">
+          <p className="text-gray-600">{'{'}</p>
+          {skills.map((skill, idx) => (
+            <div key={skill.category} className="ml-4">
+              <span className="text-blue-400">"{skill.category}"</span>
+              <span className="text-gray-600">: [</span>
+              <div className="ml-4">
+                {skill.items.map((item, i) => (
+                  <span key={item}>
+                    <span className="text-emerald-400">"{item}"</span>
+                    {i < skill.items.length - 1 && <span className="text-gray-600">, </span>}
+                  </span>
+                ))}
+              </div>
+              <span className="text-gray-600">]{idx < skills.length - 1 ? ',' : ''}</span>
+            </div>
+          ))}
+          <p className="text-gray-600">{'}'}</p>
+        </div>
+      </div>
+
+      {/* Work Experience */}
+      <div className="mb-8">
+        <div className="flex items-center gap-3 mb-6">
+          <Briefcase className="w-5 h-5 text-blue-400" />
+          <h2 className="text-2xl font-semibold text-white">Experiência</h2>
+        </div>
+
+        <div className="space-y-4">
+          {workItems.map((item, index) => (
+            <Link
+              key={item.title}
+              href={item.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group block border border-gray-800/60 bg-[#161616] hover:border-blue-400/50 hover:bg-[#1a1a1a] transition-all duration-300"
+            >
+              {/* Card Header */}
+              <div className="flex items-center justify-between px-4 py-2 border-b border-gray-800/40 bg-[#1a1a1a]">
+                <div className="flex items-center gap-2">
+                  <div className="flex gap-1">
+                    <span className="w-2 h-2 rounded-full bg-gray-600" />
+                    <span className="w-2 h-2 rounded-full bg-gray-600" />
+                    <span className="w-2 h-2 rounded-full bg-gray-600" />
+                  </div>
+                  <span className="text-[10px] text-gray-600 font-mono ml-2">work/{index + 1}</span>
+                </div>
+
+                {item.current && (
+                  <span className="flex items-center gap-1.5 px-2 py-0.5 text-[10px] border border-green-400/30 text-green-400">
+                    <span className="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse" />
+                    atual
+                  </span>
+                )}
+              </div>
+
+              {/* Card Content */}
+              <div className="p-5">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex-1">
+                    <h3 className="text-lg font-semibold text-white group-hover:text-blue-400 transition-colors">
+                      {item.title}
+                    </h3>
+                    <p className="text-sm text-gray-500 mt-1">
+                      {item.role}
+                    </p>
+                    <div className="flex items-center gap-1.5 text-xs text-gray-600 mt-1">
+                      <Calendar className="w-3 h-3" />
+                      {item.period}
+                    </div>
+                  </div>
+                  <ArrowUpRight className="w-5 h-5 text-gray-600 group-hover:text-blue-400 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-all" />
+                </div>
+
+                <p className="text-gray-400 text-sm mt-4 leading-relaxed">
+                  {item.description}
+                </p>
+
+                {item.technologies && (
+                  <div className="flex flex-wrap gap-2 mt-4">
+                    {item.technologies.map((tech) => (
+                      <span
+                        key={tech}
+                        className="px-2 py-0.5 text-[11px] border border-gray-700/50 text-gray-500 bg-gray-800/20"
+                      >
+                        {tech}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </Link>
+          ))}
+        </div>
+      </div>
+
+      {/* Footer Terminal */}
+      <div className="border border-gray-800/60 bg-[#161616] p-4">
+        <div className="flex items-center gap-2 font-mono text-xs text-gray-500">
+          <span className="text-emerald-400">❯</span>
+          <span className="text-gray-600">echo</span>
+          <span className="text-gray-400">"Obrigado por visitar!"</span>
+          <span className="animate-pulse">_</span>
+        </div>
       </div>
     </div>
   )
@@ -46,7 +219,7 @@ function page() {
 
 export const metadata: Metadata = {
   title: "Sobre mim",
-  description: "Alguns dos projetos em que trabalhei.",
+  description: "Conheça mais sobre minha trajetória como Engenheiro de Software & SRE.",
 }
 
-export default page
+export default SobrePage

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,44 +1,159 @@
-import { MapPin, FolderGit2 } from "lucide-react"
+import { MapPin, Terminal, Zap, Coffee, ArrowUpRight } from "lucide-react"
 import Image from "next/image"
-// import Profile  from "../../public/joaquimsnjr.jpg"
 import Link from "next/link"
 
 export function Header() {
   return (
-    <header className="mb-16 space-y-4">
-      <h1 className="text-4xl font-bold mb-4 animate-fade-in text-white">
-        <span className="flex items-center gap-4">
-          <Image
-            width={80}
-            height={80}
-            src="https://res.cloudinary.com/dy5xyare1/image/upload/v1764384343/ProfileBW_jddt02.png"
-            alt="Homem jovem com cabelo escuro e barba fina, pensativo, segurando o queixo com a mão, com fundo branco, usando camiseta preta."
-            placeholder="blur"
-            blurDataURL="https://res.cloudinary.com/dy5xyare1/image/upload/v1764384343/ProfileBW_jddt02.png"
-            priority
-          />
-          <div className="flex justify-end flex-col sm:flex-row sm:items-center sm:gap-4 w-full">
-            <h1 className="font-semibold sm:text-[1.7rem] md:text-[2.5rem] leading-none flex-auto underline decoration-blue-400 decoration-4 underline-offset-4">Joaquim Silva</h1>
-            <h3 className="text-[0.80rem] text-gray-400 leading-none sm:flex-wrap mt-2">~/Development/joaquimsnjr.tech</h3>
+    <header className="mb-16 animate-fade-in">
+      {/* Terminal Window Container */}
+      <div className="border border-gray-800/60 bg-[#161616] overflow-hidden">
+
+        {/* Terminal Header Bar */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-800/60 bg-[#1a1a1a]">
+          <div className="flex items-center gap-2">
+            <div className="flex gap-1.5">
+              <span className="w-3 h-3 rounded-full bg-red-500/80" />
+              <span className="w-3 h-3 rounded-full bg-yellow-500/80" />
+              <span className="w-3 h-3 rounded-full bg-green-500/80" />
+            </div>
+            <span className="ml-3 text-xs text-gray-500 font-mono">zsh</span>
           </div>
-        </span>
-      </h1>
-      <div className="flex flex-col gap-2 text-gray-350 group border p-4 border-gray-800/40 bg-[#161616]">
-        <div className="flex items-center gap-2 text-[0.95rem]">
-          <MapPin className="w-4 h-4"/>
-          São Paulo, Brasil
+          <div className="flex items-center gap-2 text-xs text-gray-500 font-mono">
+            <span className="hidden sm:inline">~/Development/joaquimsnjr.tech</span>
+            <span className="sm:hidden">~/joaquimsnjr.tech</span>
+          </div>
         </div>
-        <div className="flex items-center gap-2 text-[0.95rem]">
-            SRE & Software Engineer | Mission Critical Systems
+
+        {/* Main Content */}
+        <div className="p-6 md:p-8">
+
+          {/* Profile Section */}
+          <div className="flex flex-col sm:flex-row gap-6 items-start">
+
+            {/* Avatar with Status */}
+            <div className="relative group">
+              <div className="absolute -inset-0.5 bg-gradient-to-r from-blue-500 to-cyan-500 rounded-full opacity-0 group-hover:opacity-75 blur transition duration-500" />
+              <div className="relative">
+                <Image
+                  width={100}
+                  height={100}
+                  src="https://res.cloudinary.com/dy5xyare1/image/upload/v1764384343/ProfileBW_jddt02.png"
+                  alt="Joaquim Silva - SRE & Software Engineer"
+                  className="rounded-full border-2 border-gray-800 group-hover:border-blue-400/50 transition-colors duration-300"
+                  placeholder="blur"
+                  blurDataURL="https://res.cloudinary.com/dy5xyare1/image/upload/v1764384343/ProfileBW_jddt02.png"
+                  priority
+                />
+                {/* Online Status */}
+                <span className="absolute bottom-1 right-1 w-4 h-4 bg-green-500 rounded-full border-2 border-[#161616]">
+                  <span className="absolute inset-0 bg-green-500 rounded-full animate-ping opacity-75" />
+                </span>
+              </div>
+            </div>
+
+            {/* Info */}
+            <div className="flex-1 space-y-4">
+
+              {/* Name & Title */}
+              <div>
+                <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-white mb-1">
+                  Joaquim Silva
+                </h1>
+                <p className="text-gray-400 font-mono text-sm">
+                  <span className="text-blue-400">const</span> role = <span className="text-emerald-400">"SRE & Software Engineer"</span>;
+                </p>
+              </div>
+
+              {/* Location & Status */}
+              <div className="flex flex-wrap items-center gap-4 text-sm text-gray-400">
+                <div className="flex items-center gap-1.5">
+                  <MapPin className="w-4 h-4 text-blue-400" />
+                  <span>São Paulo, Brasil</span>
+                </div>
+                <div className="flex items-center gap-1.5">
+                  <Zap className="w-4 h-4 text-yellow-400" />
+                  <span>Mission Critical Systems</span>
+                </div>
+                <div className="flex items-center gap-1.5">
+                  <Coffee className="w-4 h-4 text-orange-400" />
+                  <span className="text-gray-500">Powered by coffee</span>
+                </div>
+              </div>
+
+            </div>
+          </div>
+
+          {/* Divider */}
+          <div className="my-6 border-t border-dashed border-gray-800/60" />
+
+          {/* Command Line Style Bio */}
+          <div className="font-mono text-sm space-y-2 text-gray-400">
+            <div className="flex items-start gap-2">
+              <span className="text-emerald-400 select-none">❯</span>
+              <span className="text-gray-500">cat</span>
+              <span className="text-white">about.md</span>
+            </div>
+            <div className="pl-5 text-gray-300 leading-relaxed">
+              Engenheiro focado em <span className="text-blue-400">confiabilidade</span>,
+              <span className="text-blue-400"> performance</span> e
+              <span className="text-blue-400"> sistemas distribuídos</span>.
+              Construindo infraestrutura que não dorme.
+            </div>
+          </div>
+
+          {/* Divider */}
+          <div className="my-6 border-t border-dashed border-gray-800/60" />
+
+          {/* Navigation Links */}
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href="/projects"
+              className="group flex items-center gap-2 px-4 py-2.5 bg-[#1a1a1a] border border-gray-800/60 hover:border-blue-400/50 transition-all duration-300"
+            >
+              <Terminal className="w-4 h-4 text-gray-500 group-hover:text-blue-400 transition-colors" />
+              <span className="text-sm text-gray-300 group-hover:text-white transition-colors">
+                projetos
+              </span>
+              <ArrowUpRight className="w-3 h-3 text-gray-600 group-hover:text-blue-400 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-all" />
+            </Link>
+
+            <Link
+              href="/talks"
+              className="group flex items-center gap-2 px-4 py-2.5 bg-[#1a1a1a] border border-gray-800/60 hover:border-blue-400/50 transition-all duration-300"
+            >
+              <span className="text-gray-500 group-hover:text-blue-400 transition-colors font-mono text-sm">[t]</span>
+              <span className="text-sm text-gray-300 group-hover:text-white transition-colors">
+                talks
+              </span>
+              <ArrowUpRight className="w-3 h-3 text-gray-600 group-hover:text-blue-400 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-all" />
+            </Link>
+
+            <a
+              href="https://github.com/joaquimsnjunior"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group flex items-center gap-2 px-4 py-2.5 bg-[#1a1a1a] border border-gray-800/60 hover:border-blue-400/50 transition-all duration-300"
+            >
+              <svg className="w-4 h-4 text-gray-500 group-hover:text-blue-400 transition-colors" fill="currentColor" viewBox="0 0 24 24">
+                <path fillRule="evenodd" clipRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
+              </svg>
+              <span className="text-sm text-gray-300 group-hover:text-white transition-colors">
+                github
+              </span>
+              <ArrowUpRight className="w-3 h-3 text-gray-600 group-hover:text-blue-400 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-all" />
+            </a>
+          </div>
+
         </div>
-        <div className="mt-2 group border p-2 border-gray-800/50">
-          <Link href="/talks">
-            <span className="text-white/85 hover:text-blue-400 transition-colors duration-200 text-[0.80rem]">[t] talks</span>
-          </Link>
-          <Link href="/projects" className="ml-4 group border p-2 border-gray-800 transition-colors hover:border-blue-400/50">
-            <span className="text-white/85 hover:text-blue-400 transition-colors duration-200 text-[0.80rem]"><FolderGit2 className="w-4 h-4 inline-block" /> projetos</span>
-          </Link>
+
+        {/* Terminal Footer */}
+        <div className="px-4 py-2 border-t border-gray-800/60 bg-[#1a1a1a]">
+          <div className="flex items-center gap-2 font-mono text-xs text-gray-500">
+            <span className="text-emerald-400">❯</span>
+            <span className="animate-pulse">_</span>
+          </div>
         </div>
+
       </div>
     </header>
   )

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,10 +1,13 @@
 "use client"
 import Link from "next/link"
-import { useRouter } from "next/navigation"
-import { useEffect } from "react"
+import { useRouter, usePathname } from "next/navigation"
+import { useEffect, useState } from "react"
+import { Command } from "lucide-react"
 
 export function Navbar() {
   const router = useRouter()
+  const pathname = usePathname()
+  const [showShortcuts, setShowShortcuts] = useState(false)
 
   useEffect(() => {
     const handleKeyPress = (event: KeyboardEvent) => {
@@ -40,29 +43,142 @@ export function Navbar() {
     return () => window.removeEventListener("keydown", handleKeyPress)
   }, [router])
 
+  const navItems = [
+    { href: "/", label: "home", shortcut: "h" },
+    { href: "/blog", label: "blog", shortcut: "b" },
+    { href: "/projects", label: "projects", shortcut: "p" },
+    { href: "/sobre", label: "sobre", shortcut: "s" },
+  ]
+
+  const isActive = (href: string) => {
+    if (href === "/") return pathname === "/"
+    return pathname.startsWith(href)
+  }
+
   return (
-    <nav className="flex items-center justify-between mb-12 text-sm">
-      <div className="flex space-x-4">
+    <nav className="mb-12">
+      {/* Main Navigation Bar */}
+      <div className="flex items-center justify-between border border-gray-800/60 bg-[#161616]">
+
+        {/* Logo / Brand */}
         <Link
           href="/"
-          className="hover:text-blue-400 transition-colors duration-200"
+          className="group flex items-center gap-2 px-4 py-3 border-r border-gray-800/60 hover:bg-[#1a1a1a] transition-colors duration-200"
         >
-          [h]/home
+          <span className="text-emerald-400 font-mono text-sm">❯</span>
+          <span className="text-gray-400 group-hover:text-white transition-colors font-mono text-sm">
+            jsnj<span className="text-blue-400">.</span>tech
+          </span>
         </Link>
-        <Link
-          href="/blog"
-          prefetch={true}
-          className="hover:text-blue-400 transition-colors duration-200"
+
+        {/* Navigation Links */}
+        <div className="flex-1 flex items-center">
+          <div className="hidden sm:flex items-center">
+            {navItems.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                prefetch={true}
+                className={`
+                  group relative flex items-center gap-2 px-4 py-3 border-r border-gray-800/60 
+                  transition-all duration-200 hover:bg-[#1a1a1a]
+                  ${isActive(item.href)
+                    ? "text-blue-400 bg-blue-400/5"
+                    : "text-gray-400 hover:text-white"
+                  }
+                `}
+              >
+                {/* Shortcut Key Badge */}
+                <span className={`
+                  font-mono text-[10px] px-1.5 py-0.5 border
+                  ${isActive(item.href)
+                    ? "border-blue-400/30 text-blue-400 bg-blue-400/10"
+                    : "border-gray-700 text-gray-600 group-hover:border-gray-600 group-hover:text-gray-400"
+                  }
+                `}>
+                  {item.shortcut}
+                </span>
+
+                {/* Label */}
+                <span className="text-sm">{item.label}</span>
+
+                {/* Active Indicator */}
+                {isActive(item.href) && (
+                  <span className="absolute bottom-0 left-0 right-0 h-[2px] bg-blue-400" />
+                )}
+              </Link>
+            ))}
+          </div>
+
+          {/* Mobile Menu */}
+          <div className="sm:hidden flex-1 px-4 py-3">
+            <div className="flex items-center gap-2 text-gray-400 font-mono text-sm">
+              <span className="text-emerald-400">❯</span>
+              <span className="text-gray-500">cd</span>
+              <span className="text-white">{pathname === "/" ? "~" : pathname}</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Keyboard Shortcuts Toggle */}
+        <button
+          onClick={() => setShowShortcuts(!showShortcuts)}
+          className="hidden md:flex items-center gap-2 px-4 py-3 border-l border-gray-800/60 text-gray-500 hover:text-gray-300 hover:bg-[#1a1a1a] transition-all duration-200"
+          title="Keyboard shortcuts"
         >
-          [b]/blog
-        </Link>
-        <Link
-          href="/sobre"
-          prefetch={true}
-          className="hover:text-blue-400 transition-colors duration-200"
-        >
-          [s]/sobre
-        </Link>
+          <Command className="w-4 h-4" />
+          <span className="text-xs font-mono">keys</span>
+        </button>
+
+      </div>
+
+      {/* Keyboard Shortcuts Panel */}
+      {showShortcuts && (
+        <div className="mt-2 border border-gray-800/60 bg-[#161616] p-4 animate-fade-in-up">
+          <div className="flex items-center gap-2 mb-3 text-xs text-gray-500">
+            <Command className="w-3 h-3" />
+            <span>Keyboard shortcuts</span>
+          </div>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            {navItems.map((item) => (
+              <div key={item.href} className="flex items-center gap-2">
+                <kbd className="px-2 py-1 bg-gray-800/50 border border-gray-700 text-gray-400 font-mono text-xs">
+                  {item.shortcut}
+                </kbd>
+                <span className="text-gray-500 text-xs">{item.label}</span>
+              </div>
+            ))}
+            <div className="flex items-center gap-2">
+              <kbd className="px-2 py-1 bg-gray-800/50 border border-gray-700 text-gray-400 font-mono text-xs">
+                t
+              </kbd>
+              <span className="text-gray-500 text-xs">talks</span>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Mobile Navigation Drawer */}
+      <div className="sm:hidden mt-2 grid grid-cols-4 gap-1">
+        {navItems.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={`
+              flex flex-col items-center gap-1 py-2 border border-gray-800/60
+              transition-all duration-200
+              ${isActive(item.href)
+                ? "bg-blue-400/10 border-blue-400/30 text-blue-400"
+                : "bg-[#161616] text-gray-500 hover:text-white hover:border-gray-700"
+              }
+            `}
+          >
+            <span className="font-mono text-[10px] px-1.5 py-0.5 border border-gray-700/50">
+              {item.shortcut}
+            </span>
+            <span className="text-[11px]">{item.label}</span>
+          </Link>
+        ))}
       </div>
     </nav>
   )

--- a/src/components/posts.tsx
+++ b/src/components/posts.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useRef } from "react"
 import { useRouter } from "next/navigation"
 import type { MDXFileData } from "@/lib/blog"
 import { PostItem } from "./post-item"
+import { Search, X, CornerDownLeft } from "lucide-react"
 
 type PostsProps = {
   posts: MDXFileData[]
@@ -17,7 +18,8 @@ export function Posts({ posts }: PostsProps) {
   const selectedItemRef = useRef<HTMLDivElement>(null)
 
   const filteredPosts = posts.filter((item) =>
-    item.metadata.title.toLowerCase().includes(searchQuery.toLowerCase()),
+    item.metadata.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    item.metadata.description?.toLowerCase().includes(searchQuery.toLowerCase())
   )
 
   useEffect(() => {
@@ -76,32 +78,119 @@ export function Posts({ posts }: PostsProps) {
 
   return (
     <>
+      {/* Search Modal - Terminal Style */}
       {isSearching && (
-        <div className="fixed bottom-4 left-4 right-4 max-w-2xl mx-auto bg-black/50 backdrop-blur-sm border border-gray-800 p-2">
-          <div className="flex items-center text-gray-400">
-            <span className="text-blue-400 mr-2">/</span>
-            <input
-              type="text"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="flex-1 bg-transparent outline-none"
-              autoFocus
-              placeholder="pesquisar posts..."
-              aria-label="Search posts"
-              role="searchbox"
-              aria-expanded={filteredPosts.length > 0}
-              aria-controls="search-results"
-              aria-activedescendant={
-                isSearching && filteredPosts.length > 0
-                  ? `post-${filteredPosts[selectedIndex].slug}`
-                  : undefined
-              }
-            />
+        <div className="fixed inset-0 z-50 flex items-start justify-center pt-[20vh] bg-black/60 backdrop-blur-sm">
+          <div className="w-full max-w-2xl mx-4 border border-gray-800/80 bg-[#161616] shadow-2xl shadow-black/50 animate-fade-in-up">
+            {/* Search Header */}
+            <div className="flex items-center justify-between px-4 py-3 border-b border-gray-800/60 bg-[#1a1a1a]">
+              <div className="flex items-center gap-2">
+                <div className="flex gap-1.5">
+                  <span className="w-3 h-3 rounded-full bg-red-500/80" />
+                  <span className="w-3 h-3 rounded-full bg-yellow-500/80" />
+                  <span className="w-3 h-3 rounded-full bg-green-500/80" />
+                </div>
+                <span className="ml-3 text-xs text-gray-500 font-mono">search</span>
+              </div>
+              <button
+                onClick={() => {
+                  setIsSearching(false)
+                  setSearchQuery("")
+                }}
+                className="text-gray-500 hover:text-white transition-colors"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+
+            {/* Search Input */}
+            <div className="flex items-center gap-3 px-4 py-4 border-b border-gray-800/60">
+              <span className="text-emerald-400 font-mono">❯</span>
+              <span className="text-gray-500 font-mono text-sm">grep</span>
+              <input
+                type="text"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="flex-1 bg-transparent outline-none text-white font-mono placeholder:text-gray-600"
+                autoFocus
+                placeholder="buscar artigos..."
+                aria-label="Search posts"
+                role="searchbox"
+                aria-expanded={filteredPosts.length > 0}
+                aria-controls="search-results"
+                aria-activedescendant={
+                  isSearching && filteredPosts.length > 0
+                    ? `post-${filteredPosts[selectedIndex].slug}`
+                    : undefined
+                }
+              />
+            </div>
+
+            {/* Results Count */}
+            <div className="px-4 py-2 text-xs text-gray-600 font-mono border-b border-gray-800/40">
+              {filteredPosts.length} resultado{filteredPosts.length !== 1 ? 's' : ''} encontrado{filteredPosts.length !== 1 ? 's' : ''}
+            </div>
+
+            {/* Results List */}
+            <div className="max-h-[40vh] overflow-y-auto">
+              {filteredPosts.length > 0 ? (
+                filteredPosts.slice(0, 8).map((item, index) => (
+                  <button
+                    key={item.slug}
+                    onClick={() => router.push(`/blog/${item.slug}`)}
+                    className={`w-full text-left px-4 py-3 flex items-center gap-3 transition-colors ${index === selectedIndex
+                        ? 'bg-blue-400/10 border-l-2 border-blue-400'
+                        : 'hover:bg-gray-800/30 border-l-2 border-transparent'
+                      }`}
+                  >
+                    <div className="flex-1 min-w-0">
+                      <p className={`text-sm font-medium truncate ${index === selectedIndex ? 'text-blue-400' : 'text-gray-300'
+                        }`}>
+                        {item.metadata.title}
+                      </p>
+                      <p className="text-xs text-gray-600 truncate mt-0.5">
+                        {item.metadata.description}
+                      </p>
+                    </div>
+                    {index === selectedIndex && (
+                      <div className="flex items-center gap-1 text-gray-600">
+                        <CornerDownLeft className="w-3 h-3" />
+                        <span className="text-[10px]">enter</span>
+                      </div>
+                    )}
+                  </button>
+                ))
+              ) : (
+                <div className="px-4 py-8 text-center">
+                  <p className="text-gray-600 font-mono text-sm">Nenhum artigo encontrado</p>
+                  <p className="text-gray-700 text-xs mt-1">Tente outro termo de busca</p>
+                </div>
+              )}
+            </div>
+
+            {/* Footer */}
+            <div className="flex items-center justify-between px-4 py-2 border-t border-gray-800/60 bg-[#1a1a1a] text-xs text-gray-600">
+              <div className="flex items-center gap-4">
+                <div className="flex items-center gap-1">
+                  <kbd className="px-1.5 py-0.5 bg-gray-800 border border-gray-700 text-[10px]">↑↓</kbd>
+                  <span>navegar</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <kbd className="px-1.5 py-0.5 bg-gray-800 border border-gray-700 text-[10px]">enter</kbd>
+                  <span>abrir</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <kbd className="px-1.5 py-0.5 bg-gray-800 border border-gray-700 text-[10px]">esc</kbd>
+                  <span>fechar</span>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       )}
 
-      <div className="space-y-8 sm:space-y-4">
+      {/* Posts List */}
+      <div className="space-y-3">
         {filteredPosts.map((item, index) => (
           <div
             key={item.slug}
@@ -112,6 +201,7 @@ export function Posts({ posts }: PostsProps) {
             <PostItem
               post={item}
               isSelected={isSearching && index === selectedIndex}
+              index={index}
             />
           </div>
         ))}


### PR DESCRIPTION
- Add terminal-style navigation bar with macOS dots visual
- Implement keyboard shortcuts panel (h, b, p, s, t keys)
- Add active state indicators with blue accent line
- Create responsive mobile navigation with grid layout
- Add path display for mobile (❯ cd ~/path)
- Include shortcut key badges on navigation items
- Add smooth transitions and hover effects