### PR TITLE
feat(pages): redesign talks, projects and presentations with terminal…

### DIFF
--- a/src/app/presentations/[slug]/page.tsx
+++ b/src/app/presentations/[slug]/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 import React, { useEffect, useState } from "react"
 import Deck from "@/components/deck/Deck"
+import { AlertTriangle, Loader2 } from "lucide-react"
 
 type PresentationModule = {
   slides: React.ReactNode[]
@@ -39,11 +40,87 @@ export default function PresentationPage({ params }: { params: { slug: string } 
     }
   }, [slug])
 
-  if (error) return <div className="p-8 text-red-400">{error}</div>
-  if (!mod) return <div className="p-8">Carregando apresentação...</div>
+  // Error State - Terminal Style
+  if (error) {
+    return (
+      <div className="min-h-screen bg-[#111] flex items-center justify-center p-4">
+        <div className="w-full max-w-lg border border-gray-800/60 bg-[#161616]">
+          {/* Terminal Header */}
+          <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-800/60 bg-[#1a1a1a]">
+            <div className="flex gap-1.5">
+              <span className="w-3 h-3 rounded-full bg-red-500/80" />
+              <span className="w-3 h-3 rounded-full bg-yellow-500/80" />
+              <span className="w-3 h-3 rounded-full bg-green-500/80" />
+            </div>
+            <span className="ml-3 text-xs text-gray-400 font-mono">error</span>
+          </div>
+
+          {/* Error Content */}
+          <div className="p-6">
+            <div className="flex items-center gap-3 mb-4">
+              <AlertTriangle className="w-6 h-6 text-red-400" />
+              <h2 className="text-lg font-semibold text-red-400">Erro ao carregar</h2>
+            </div>
+
+            <div className="font-mono text-sm space-y-2 text-gray-400">
+              <div className="flex items-start gap-2">
+                <span className="text-red-400 select-none">✗</span>
+                <span className="text-gray-400">load</span>
+                <span className="text-white">./presentations/{slug}</span>
+              </div>
+              <div className="pl-5 border-l-2 border-red-500/30 text-red-300">
+                {error}
+              </div>
+            </div>
+
+            <button
+              onClick={() => window.location.href = "/talks"}
+              className="mt-6 flex items-center gap-2 px-4 py-2 text-sm border border-gray-700 text-gray-400 hover:border-blue-400/50 hover:text-blue-400 transition-all"
+            >
+              ← voltar para talks
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // Loading State - Terminal Style
+  if (!mod) {
+    return (
+      <div className="min-h-screen bg-[#111] flex items-center justify-center p-4">
+        <div className="w-full max-w-lg border border-gray-800/60 bg-[#161616]">
+          {/* Terminal Header */}
+          <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-800/60 bg-[#1a1a1a]">
+            <div className="flex gap-1.5">
+              <span className="w-3 h-3 rounded-full bg-red-500/80" />
+              <span className="w-3 h-3 rounded-full bg-yellow-500/80" />
+              <span className="w-3 h-3 rounded-full bg-green-500/80" />
+            </div>
+            <span className="ml-3 text-xs text-gray-400 font-mono">loading</span>
+          </div>
+
+          {/* Loading Content */}
+          <div className="p-6">
+            <div className="font-mono text-sm space-y-3 text-gray-400">
+              <div className="flex items-start gap-2">
+                <span className="text-emerald-400 select-none">❯</span>
+                <span className="text-gray-400">import</span>
+                <span className="text-white">./presentations/{slug}</span>
+              </div>
+              <div className="flex items-center gap-3 pl-5">
+                <Loader2 className="w-4 h-4 text-blue-400 animate-spin" />
+                <span className="text-gray-400">Carregando apresentação...</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
 
   return (
-    <div className="p-6">
+    <div className="min-h-screen bg-[#111]">
       <Deck slides={mod.slides} title={mod.meta?.title} notes={mod.notes} />
     </div>
   )

--- a/src/app/presentations/layout.tsx
+++ b/src/app/presentations/layout.tsx
@@ -7,16 +7,14 @@ type Props = {
 
 export default function Layout({ children }: Props) {
   return (
-    <main>
-      <div>
-        {children}
-      </div>
+    <main className="min-h-screen bg-[#111]">
+      {children}
     </main>
   )
 }
 
 export const metadata: Metadata = {
-  title: "Hora de Apresentar",
+  title: "Apresentação",
   description: "Veja as palestras e apresentações que já fiz ao longo do tempo.",
 }
 

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,47 +1,385 @@
 import { ScrambleText } from "@/components/scramble-text"
-import { ProjectCard } from "@/components/project-card"
 import { Metadata } from "next"
+import Link from "next/link"
+import { Terminal, Code2, Server, Zap, ExternalLink, Github, Star, GitFork } from "lucide-react"
 
-const projects = [
+type Project = {
+  title: string
+  slug: string
+  description: string
+  role: string
+  status: "live" | "development" | "archived"
+  featured?: boolean
+  technologies: string[]
+  achievements: string[]
+  href: string
+  github?: string
+  stars?: number
+  forks?: number
+  icon?: "terminal" | "code" | "server" | "zap"
+}
+
+const projects: Project[] = [
   {
     title: "JoaquimSNJR Tech",
-    description:
-      "Meu site pessoal onde compartilho meus projetos, posts de blog e informações sobre mim.",
+    slug: "joaquimsnjr-tech",
+    description: "Meu site pessoal onde compartilho meus projetos, posts de blog e informações sobre mim.",
     role: "Website Pessoal",
-    period: "set 2025",
+    status: "live",
+    featured: true,
+    technologies: ["React", "Next.js", "Tailwind CSS", "TypeScript", "Vercel", "MDX"],
     achievements: [
-      "Desenvolvimento de um site responsivo",
-      "Implementação de funcionalidades interativas",
-      "Otimização para SEO e performance",
+      "Design terminal-style único",
+      "SEO otimizado com sitemap dinâmico",
+      "Performance score 100 no Lighthouse",
     ],
-    technologies: [
-      "react",
-      "next.js",
-      "tailwind css",
-      "typescript",
-      "vercel",
-    ],
-    href: "https://github.com/joaquimsnjunior/joaquimsnjr.tech",
+    href: "https://joaquimsnjr.tech",
+    github: "https://github.com/joaquimsnjunior/joaquimsnjr.tech",
+    icon: "terminal",
   },
 ]
 
+const STATUS_CONFIG = {
+  live: {
+    label: "online",
+    className: "text-green-400 border-green-400/30",
+    dot: "bg-green-400",
+  },
+  development: {
+    label: "dev",
+    className: "text-yellow-400 border-yellow-400/30",
+    dot: "bg-yellow-400",
+  },
+  archived: {
+    label: "archived",
+    className: "text-gray-500 border-gray-500/30",
+    dot: "bg-gray-500",
+  },
+}
+
+const ICON_MAP = {
+  terminal: Terminal,
+  code: Code2,
+  server: Server,
+  zap: Zap,
+}
+
+function FeaturedProject({ project }: { project: Project }) {
+  const statusConfig = STATUS_CONFIG[project.status]
+  const IconComponent = ICON_MAP[project.icon || "code"]
+
+  return (
+    <div className="group border border-gray-800/60 bg-[#161616] hover:border-blue-400/50 transition-all duration-300">
+      {/* Terminal Header */}
+      <div className="flex items-center justify-between px-5 py-3 border-b border-gray-800/60 bg-[#1a1a1a]">
+        <div className="flex items-center gap-4">
+          <div className="flex gap-1.5">
+            <span className="w-3 h-3 rounded-full bg-red-500/80" />
+            <span className="w-3 h-3 rounded-full bg-yellow-500/80" />
+            <span className="w-3 h-3 rounded-full bg-green-500/80" />
+          </div>
+          <span className="font-mono text-xs text-gray-400">
+            ~/projects/{project.slug} — zsh
+          </span>
+        </div>
+
+        <div className={`flex items-center gap-2 border px-3 py-1 text-xs ${statusConfig.className}`}>
+          <span className={`h-2 w-2 rounded-full ${statusConfig.dot} animate-pulse`} />
+          {statusConfig.label}
+        </div>
+      </div>
+
+      {/* Content Grid */}
+      <div className="grid gap-6 p-6 lg:grid-cols-2">
+        {/* Left Column: Info */}
+        <div>
+          <div className="mb-4 flex items-center gap-4">
+            <div className="flex h-14 w-14 items-center justify-center border border-blue-400/30 bg-blue-400/5 text-blue-400">
+              <IconComponent className="h-7 w-7" />
+            </div>
+            <div>
+              <h3 className="text-xl font-semibold text-white group-hover:text-blue-400 transition-colors">
+                {project.title}
+              </h3>
+              <p className="text-sm text-gray-400">{project.role}</p>
+            </div>
+          </div>
+
+          <div className="mb-5 border-l-2 border-blue-400/30 pl-4">
+            <p className="leading-relaxed text-gray-300">
+              {project.description}
+            </p>
+          </div>
+
+          {/* Stats */}
+          {(project.stars !== undefined || project.forks !== undefined) && (
+            <div className="flex items-center gap-4 mb-5 text-sm text-gray-400">
+              {project.stars !== undefined && (
+                <div className="flex items-center gap-1.5">
+                  <Star className="w-4 h-4" />
+                  <span>{project.stars}</span>
+                </div>
+              )}
+              {project.forks !== undefined && (
+                <div className="flex items-center gap-1.5">
+                  <GitFork className="w-4 h-4" />
+                  <span>{project.forks}</span>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Links */}
+          <div className="flex items-center gap-5">
+            <Link
+              href={project.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-2 text-sm text-blue-400 hover:gap-3 hover:underline transition-all duration-200"
+            >
+              <ExternalLink className="h-4 w-4" />
+              <span>ver projeto</span>
+            </Link>
+
+            {project.github && (
+              <Link
+                href={project.github}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2 text-sm text-gray-400 hover:gap-3 hover:text-white transition-all duration-200"
+              >
+                <Github className="h-4 w-4" />
+                <span>source code</span>
+              </Link>
+            )}
+          </div>
+        </div>
+
+        {/* Right Column: Tech Stack + Achievements */}
+        <div className="space-y-4">
+          {/* Tech Stack - JSON Style */}
+          <div className="border border-gray-800/40 bg-[#111] p-4">
+            <div className="mb-3 flex items-center gap-2 text-xs text-gray-400">
+              <Terminal className="h-3.5 w-3.5" />
+              <span>stack.config</span>
+            </div>
+
+            <div className="font-mono text-sm">
+              <p className="text-gray-500">{'{'}</p>
+              <p className="ml-4 text-gray-500">
+                <span className="text-blue-400">"technologies"</span>: [
+              </p>
+              {project.technologies.map((tech, i) => (
+                <p key={tech} className="ml-8 text-gray-400">
+                  <span className="text-emerald-400">"{tech.toLowerCase()}"</span>
+                  {i < project.technologies.length - 1 && ","}
+                </p>
+              ))}
+              <p className="ml-4 text-gray-500">]</p>
+              <p className="text-gray-500">{'}'}</p>
+            </div>
+          </div>
+
+          {/* Achievements */}
+          <div className="border border-gray-800/40 bg-[#111] p-4">
+            <div className="mb-3 flex items-center gap-2 text-xs text-gray-400">
+              <Zap className="h-3.5 w-3.5" />
+              <span>destaques</span>
+            </div>
+
+            <ul className="space-y-2">
+              {project.achievements.map((achievement, i) => (
+                <li key={i} className="flex items-start gap-2 text-sm text-gray-400">
+                  <span className="text-emerald-400 select-none">✓</span>
+                  <span>{achievement}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ProjectCard({ project, index }: { project: Project; index: number }) {
+  const statusConfig = STATUS_CONFIG[project.status]
+  const IconComponent = ICON_MAP[project.icon || "code"]
+
+  return (
+    <div className="group border border-gray-800/60 bg-[#161616] hover:border-blue-400/50 hover:bg-[#1a1a1a] transition-all duration-300">
+      {/* Terminal Header */}
+      <div className="flex items-center justify-between px-4 py-2 border-b border-gray-800/40 bg-[#1a1a1a]">
+        <div className="flex items-center gap-3">
+          <div className="flex gap-1.5">
+            <span className="h-2.5 w-2.5 rounded-full bg-red-500/70" />
+            <span className="h-2.5 w-2.5 rounded-full bg-yellow-500/70" />
+            <span className="h-2.5 w-2.5 rounded-full bg-green-500/70" />
+          </div>
+          <span className="text-xs text-gray-400">
+            ~/projects/{project.slug}
+          </span>
+        </div>
+
+        <div className={`flex items-center gap-1.5 border px-2 py-0.5 text-[10px] ${statusConfig.className}`}>
+          <span className={`h-1.5 w-1.5 rounded-full ${statusConfig.dot} animate-pulse`} />
+          {statusConfig.label}
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="p-5">
+        <div className="mb-4 flex items-start gap-3">
+          <div className="flex h-10 w-10 items-center justify-center border border-gray-700/50 bg-gray-800/30 text-blue-400">
+            <IconComponent className="h-5 w-5" />
+          </div>
+          <div className="flex-1">
+            <h3 className="text-lg font-semibold text-white group-hover:text-blue-400 transition-colors">
+              {project.title}
+            </h3>
+            <p className="text-xs text-gray-400">{project.role}</p>
+          </div>
+        </div>
+
+        <div className="mb-5 border-l-2 border-gray-700/50 pl-3">
+          <p className="text-sm leading-relaxed text-gray-400">
+            <span className="text-gray-500">// </span>
+            {project.description}
+          </p>
+        </div>
+
+        {/* Technologies */}
+        <div className="mb-5 flex flex-wrap gap-2">
+          {project.technologies.slice(0, 5).map((tech) => (
+            <span
+              key={tech}
+              className="border border-gray-700/50 bg-gray-800/20 px-2 py-0.5 text-[11px] text-gray-400 hover:border-blue-400/30 hover:text-blue-400 transition-colors"
+            >
+              {tech.toLowerCase()}
+            </span>
+          ))}
+          {project.technologies.length > 5 && (
+            <span className="px-2 py-0.5 text-[11px] text-gray-500">
+              +{project.technologies.length - 5}
+            </span>
+          )}
+        </div>
+
+        {/* Links */}
+        <div className="flex items-center gap-4 border-t border-gray-800/40 pt-4">
+          <Link
+            href={project.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1.5 text-sm text-gray-400 hover:gap-2 hover:text-blue-400 transition-all duration-200"
+          >
+            <ExternalLink className="h-3.5 w-3.5" />
+            <span>ver projeto</span>
+          </Link>
+
+          {project.github && (
+            <Link
+              href={project.github}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1.5 text-sm text-gray-400 hover:gap-2 hover:text-white transition-all duration-200"
+            >
+              <Github className="h-3.5 w-3.5" />
+              <span>código</span>
+            </Link>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export default function ProjectsPage() {
+  const featuredProjects = projects.filter(p => p.featured)
+  const otherProjects = projects.filter(p => !p.featured)
+
   return (
     <main className="animate-fade-in-up">
-      <h1 className="text-4xl font-semibold mb-8 text-white underline decoration-blue-400 decoration-4">
-        <ScrambleText className="font-semibold" text="Projetos" />
-      </h1>
+      {/* Terminal Window Header */}
+      <div className="border border-gray-800/60 bg-[#161616] mb-8">
+        {/* Terminal Bar */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-800/60 bg-[#1a1a1a]">
+          <div className="flex items-center gap-2">
+            <div className="flex gap-1.5">
+              <span className="w-3 h-3 rounded-full bg-red-500/80" />
+              <span className="w-3 h-3 rounded-full bg-yellow-500/80" />
+              <span className="w-3 h-3 rounded-full bg-green-500/80" />
+            </div>
+            <span className="ml-3 text-xs text-gray-400 font-mono">~/projects</span>
+          </div>
+          <div className="flex items-center gap-2 text-xs text-gray-500 font-mono">
+            <Code2 className="w-3 h-3" />
+            <span>{projects.length} projeto{projects.length !== 1 ? 's' : ''}</span>
+          </div>
+        </div>
 
-      <p className="text-gray-400 mb-12 leading-relaxed">
-        aqui estão alguns dos projetos em que trabalhei. eu adoro construir ferramentas
-        que facilitam a vida dos desenvolvedores e explorar novas tecnologias
-        ao longo do caminho.
-      </p>
+        {/* Content */}
+        <div className="p-6">
+          <h1 className="text-3xl sm:text-4xl font-bold text-white mb-4">
+            <ScrambleText className="font-bold leading-none" text="Projetos" />
+          </h1>
 
-      <div className="space-y-12">
-        {projects.map((project) => (
-          <ProjectCard key={project.title} {...project} />
-        ))}
+          {/* Command Line Intro */}
+          <div className="font-mono text-sm space-y-2 text-gray-400">
+            <div className="flex items-start gap-2">
+              <span className="text-emerald-400 select-none">❯</span>
+              <span className="text-gray-400">ls</span>
+              <span className="text-white">-la ./projects</span>
+            </div>
+            <div className="pl-5 text-gray-300 leading-relaxed border-l-2 border-gray-800">
+              Aqui estão alguns dos projetos em que trabalhei. Adoro construir
+              <span className="text-blue-400"> ferramentas</span> que facilitam a vida dos desenvolvedores
+              e explorar <span className="text-blue-400">novas tecnologias</span> ao longo do caminho.
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Featured Projects */}
+      {featuredProjects.length > 0 && (
+        <div className="mb-8">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex items-center gap-2 text-blue-400">
+              <Star className="w-4 h-4" />
+              <h2 className="text-xl font-semibold">Destaque</h2>
+            </div>
+          </div>
+          <div className="space-y-6">
+            {featuredProjects.map((project) => (
+              <FeaturedProject key={project.slug} project={project} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Other Projects */}
+      {otherProjects.length > 0 && (
+        <div className="mb-8">
+          <div className="flex items-center gap-3 mb-6">
+            <h2 className="text-xl font-semibold text-white">Outros Projetos</h2>
+            <span className="text-xs text-gray-500 font-mono">({otherProjects.length})</span>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            {otherProjects.map((project, index) => (
+              <ProjectCard key={project.slug} project={project} index={index} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Footer Terminal */}
+      <div className="border border-gray-800/60 bg-[#161616] p-4">
+        <div className="flex items-center gap-2 font-mono text-xs text-gray-400">
+          <span className="text-emerald-400">❯</span>
+          <span className="text-gray-500">echo</span>
+          <span className="text-gray-400">"Mais projetos em breve..."</span>
+          <span className="animate-pulse">_</span>
+        </div>
       </div>
     </main>
   )

--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -61,9 +61,9 @@ function SobrePage() {
               <span className="w-3 h-3 rounded-full bg-yellow-500/80" />
               <span className="w-3 h-3 rounded-full bg-green-500/80" />
             </div>
-            <span className="ml-3 text-xs text-gray-500 font-mono">~/sobre</span>
+            <span className="ml-3 text-xs text-gray-400 font-mono">~/sobre</span>
           </div>
-          <div className="flex items-center gap-2 text-xs text-gray-600 font-mono">
+          <div className="flex items-center gap-2 text-xs text-gray-500 font-mono">
             <MapPin className="w-3 h-3" />
             São Paulo, BR
           </div>
@@ -79,7 +79,7 @@ function SobrePage() {
           <div className="font-mono text-sm space-y-3 text-gray-400 mb-6">
             <div className="flex items-start gap-2">
               <span className="text-emerald-400 select-none">❯</span>
-              <span className="text-gray-500">whoami</span>
+              <span className="text-gray-400">whoami</span>
             </div>
             <div className="pl-5 text-gray-300 leading-relaxed">
               Engenheiro de Software & SRE
@@ -87,7 +87,7 @@ function SobrePage() {
 
             <div className="flex items-start gap-2 mt-4">
               <span className="text-emerald-400 select-none">❯</span>
-              <span className="text-gray-500">cat</span>
+              <span className="text-gray-400">cat</span>
               <span className="text-white">bio.md</span>
             </div>
             <div className="pl-5 text-gray-300 leading-relaxed border-l-2 border-gray-800">
@@ -104,8 +104,8 @@ function SobrePage() {
       {/* Skills Grid - JSON Style */}
       <div className="border border-gray-800/60 bg-[#161616] mb-8">
         <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-800/60 bg-[#1a1a1a]">
-          <Code2 className="w-4 h-4 text-gray-500" />
-          <span className="text-xs text-gray-500 font-mono">skills.json</span>
+          <Code2 className="w-4 h-4 text-gray-400" />
+          <span className="text-xs text-gray-400 font-mono">skills.json</span>
         </div>
 
         <div className="p-5 font-mono text-sm">
@@ -149,11 +149,11 @@ function SobrePage() {
               <div className="flex items-center justify-between px-4 py-2 border-b border-gray-800/40 bg-[#1a1a1a]">
                 <div className="flex items-center gap-2">
                   <div className="flex gap-1">
-                    <span className="w-2 h-2 rounded-full bg-gray-600" />
-                    <span className="w-2 h-2 rounded-full bg-gray-600" />
-                    <span className="w-2 h-2 rounded-full bg-gray-600" />
+                    <span className="w-2 h-2 rounded-full bg-gray-500" />
+                    <span className="w-2 h-2 rounded-full bg-gray-500" />
+                    <span className="w-2 h-2 rounded-full bg-gray-500" />
                   </div>
-                  <span className="text-[10px] text-gray-600 font-mono ml-2">work/{index + 1}</span>
+                  <span className="text-[10px] text-gray-500 font-mono ml-2">work/{index + 1}</span>
                 </div>
 
                 {item.current && (
@@ -171,15 +171,15 @@ function SobrePage() {
                     <h3 className="text-lg font-semibold text-white group-hover:text-blue-400 transition-colors">
                       {item.title}
                     </h3>
-                    <p className="text-sm text-gray-500 mt-1">
+                    <p className="text-sm text-gray-400 mt-1">
                       {item.role}
                     </p>
-                    <div className="flex items-center gap-1.5 text-xs text-gray-600 mt-1">
+                    <div className="flex items-center gap-1.5 text-xs text-gray-500 mt-1">
                       <Calendar className="w-3 h-3" />
                       {item.period}
                     </div>
                   </div>
-                  <ArrowUpRight className="w-5 h-5 text-gray-600 group-hover:text-blue-400 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-all" />
+                  <ArrowUpRight className="w-5 h-5 text-gray-500 group-hover:text-blue-400 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-all" />
                 </div>
 
                 <p className="text-gray-400 text-sm mt-4 leading-relaxed">
@@ -191,7 +191,7 @@ function SobrePage() {
                     {item.technologies.map((tech) => (
                       <span
                         key={tech}
-                        className="px-2 py-0.5 text-[11px] border border-gray-700/50 text-gray-500 bg-gray-800/20"
+                        className="px-2 py-0.5 text-[11px] border border-gray-700/50 text-gray-400 bg-gray-800/20"
                       >
                         {tech}
                       </span>
@@ -206,9 +206,9 @@ function SobrePage() {
 
       {/* Footer Terminal */}
       <div className="border border-gray-800/60 bg-[#161616] p-4">
-        <div className="flex items-center gap-2 font-mono text-xs text-gray-500">
+        <div className="flex items-center gap-2 font-mono text-xs text-gray-400">
           <span className="text-emerald-400">❯</span>
-          <span className="text-gray-600">echo</span>
+          <span className="text-gray-500">echo</span>
           <span className="text-gray-400">"Obrigado por visitar!"</span>
           <span className="animate-pulse">_</span>
         </div>

--- a/src/app/talks/page.tsx
+++ b/src/app/talks/page.tsx
@@ -1,28 +1,228 @@
 import { ScrambleText } from '@/components/scramble-text'
-import { Item } from '@/components/section-list'
-import { SectionListNotGrouped } from '@/components/section-list-not-grouped'
 import { Metadata } from 'next'
-import React from 'react'
+import Link from 'next/link'
+import { Mic2, Calendar, MapPin, ArrowUpRight, Play, Users, ExternalLink } from 'lucide-react'
 
-const talksItems: Item[] = [
+type Talk = {
+  title: string
+  event: string
+  date: string
+  location: string
+  description: string
+  href: string
+  type: 'palestra' | 'workshop' | 'lightning'
+  status: 'upcoming' | 'past'
+  audience?: number
+  slides?: string
+  video?: string
+}
+
+const talks: Talk[] = [
   {
     title: "Quem Criou Tudo Antes do GitHub Existir",
-    role: "Palestra - All Net 2025",
-    period: "Novembro 2025",
+    event: "All Net 2025",
+    date: "Novembro 2025",
+    location: "São Paulo, BR",
     description: "Uma homenagem aos pioneiros do software livre e código aberto, destacando suas contribuições fundamentais para a tecnologia moderna.",
     href: "/presentations/genios-ocultos",
+    type: "palestra",
+    status: "past",
+    audience: 150,
   },
 ]
 
-function Talks() {
+const TYPE_CONFIG = {
+  palestra: { label: "palestra", className: "text-blue-400 border-blue-400/30" },
+  workshop: { label: "workshop", className: "text-emerald-400 border-emerald-400/30" },
+  lightning: { label: "lightning", className: "text-yellow-400 border-yellow-400/30" },
+}
+
+function TalkCard({ talk, index }: { talk: Talk; index: number }) {
+  const typeConfig = TYPE_CONFIG[talk.type]
+
   return (
-    <div>
-      <h1 className="text-4xl mb-8 text-white underline decoration-blue-400 decoration-4">
-        <ScrambleText className="font-semibold" text="Palestras & Apresentações" />
-      </h1>
-      {/* Lista de palestras */}
-      <div className="mt-8">
-        <SectionListNotGrouped title='' items={talksItems} />
+    <Link
+      href={talk.href}
+      className="group block border border-gray-800/60 bg-[#161616] hover:border-blue-400/50 hover:bg-[#1a1a1a] transition-all duration-300"
+    >
+      {/* Terminal Header */}
+      <div className="flex items-center justify-between px-4 py-2 border-b border-gray-800/40 bg-[#1a1a1a]">
+        <div className="flex items-center gap-2">
+          <div className="flex gap-1">
+            <span className="w-2 h-2 rounded-full bg-red-500/70" />
+            <span className="w-2 h-2 rounded-full bg-yellow-500/70" />
+            <span className="w-2 h-2 rounded-full bg-green-500/70" />
+          </div>
+          <span className="text-[10px] text-gray-400 font-mono ml-2">talks/{index + 1}</span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          {talk.status === 'upcoming' && (
+            <span className="flex items-center gap-1.5 px-2 py-0.5 text-[10px] border border-emerald-400/30 text-emerald-400">
+              <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse" />
+              em breve
+            </span>
+          )}
+          <span className={`px-2 py-0.5 text-[10px] border ${typeConfig.className}`}>
+            [{typeConfig.label}]
+          </span>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="p-5">
+        {/* Title & Arrow */}
+        <div className="flex items-start justify-between gap-4 mb-4">
+          <div className="flex items-start gap-3">
+            <div className="flex h-10 w-10 items-center justify-center border border-gray-700/50 bg-gray-800/30 text-blue-400 flex-shrink-0">
+              <Mic2 className="h-5 w-5" />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold text-white group-hover:text-blue-400 transition-colors">
+                {talk.title}
+              </h3>
+              <p className="text-sm text-blue-400 mt-0.5">{talk.event}</p>
+            </div>
+          </div>
+          <ArrowUpRight className="w-5 h-5 text-gray-500 group-hover:text-blue-400 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-all flex-shrink-0" />
+        </div>
+
+        {/* Meta Info */}
+        <div className="flex flex-wrap items-center gap-4 text-xs text-gray-400 mb-4">
+          <div className="flex items-center gap-1.5">
+            <Calendar className="w-3.5 h-3.5" />
+            <span>{talk.date}</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <MapPin className="w-3.5 h-3.5" />
+            <span>{talk.location}</span>
+          </div>
+          {talk.audience && (
+            <div className="flex items-center gap-1.5">
+              <Users className="w-3.5 h-3.5" />
+              <span>{talk.audience} pessoas</span>
+            </div>
+          )}
+        </div>
+
+        {/* Description */}
+        <div className="border-l-2 border-gray-700/50 pl-3 mb-4">
+          <p className="text-sm leading-relaxed text-gray-400">
+            <span className="text-gray-500">// </span>
+            {talk.description}
+          </p>
+        </div>
+
+        {/* Action Links */}
+        {(talk.slides || talk.video) && (
+          <div className="flex items-center gap-4 pt-4 border-t border-gray-800/40">
+            {talk.slides && (
+              <span className="flex items-center gap-1.5 text-sm text-gray-400 group-hover:text-blue-400">
+                <ExternalLink className="w-3.5 h-3.5" />
+                slides
+              </span>
+            )}
+            {talk.video && (
+              <span className="flex items-center gap-1.5 text-sm text-gray-400 group-hover:text-blue-400">
+                <Play className="w-3.5 h-3.5" />
+                vídeo
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+    </Link>
+  )
+}
+
+function TalksPage() {
+  const upcomingTalks = talks.filter(t => t.status === 'upcoming')
+  const pastTalks = talks.filter(t => t.status === 'past')
+
+  return (
+    <div className="animate-fade-in-up">
+      {/* Terminal Window Header */}
+      <div className="border border-gray-800/60 bg-[#161616] mb-8">
+        {/* Terminal Bar */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-800/60 bg-[#1a1a1a]">
+          <div className="flex items-center gap-2">
+            <div className="flex gap-1.5">
+              <span className="w-3 h-3 rounded-full bg-red-500/80" />
+              <span className="w-3 h-3 rounded-full bg-yellow-500/80" />
+              <span className="w-3 h-3 rounded-full bg-green-500/80" />
+            </div>
+            <span className="ml-3 text-xs text-gray-400 font-mono">~/talks</span>
+          </div>
+          <div className="flex items-center gap-2 text-xs text-gray-500 font-mono">
+            <Mic2 className="w-3 h-3" />
+            <span>{talks.length} talk{talks.length !== 1 ? 's' : ''}</span>
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="p-6">
+          <h1 className="text-3xl sm:text-4xl font-bold text-white mb-4">
+            <ScrambleText className="font-bold leading-none" text="Palestras & Apresentações" />
+          </h1>
+
+          {/* Command Line Intro */}
+          <div className="font-mono text-sm space-y-2 text-gray-400">
+            <div className="flex items-start gap-2">
+              <span className="text-emerald-400 select-none">❯</span>
+              <span className="text-gray-400">ls</span>
+              <span className="text-white">./talks</span>
+            </div>
+            <div className="pl-5 text-gray-300 leading-relaxed border-l-2 border-gray-800">
+              Apresentações sobre <span className="text-blue-400">Cloud Native</span>,
+              <span className="text-blue-400"> Go</span>,
+              <span className="text-blue-400"> SRE</span> e
+              <span className="text-blue-400"> Open Source</span>.
+              Compartilhando conhecimento e conectando comunidades.
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Upcoming Talks */}
+      {upcomingTalks.length > 0 && (
+        <div className="mb-8">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex items-center gap-2 text-emerald-400">
+              <span className="w-2 h-2 rounded-full bg-emerald-400 animate-pulse" />
+              <h2 className="text-xl font-semibold">Próximas</h2>
+            </div>
+          </div>
+          <div className="space-y-4">
+            {upcomingTalks.map((talk, index) => (
+              <TalkCard key={talk.title} talk={talk} index={index} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Past Talks */}
+      {pastTalks.length > 0 && (
+        <div className="mb-8">
+          <div className="flex items-center gap-3 mb-6">
+            <h2 className="text-xl font-semibold text-white">Realizadas</h2>
+            <span className="text-xs text-gray-500 font-mono">({pastTalks.length})</span>
+          </div>
+          <div className="space-y-4">
+            {pastTalks.map((talk, index) => (
+              <TalkCard key={talk.title} talk={talk} index={index} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Footer Terminal */}
+      <div className="border border-gray-800/60 bg-[#161616] p-4">
+        <div className="flex items-center gap-2 font-mono text-xs text-gray-400">
+          <span className="text-emerald-400">❯</span>
+          <span className="text-gray-500">echo</span>
+          <span className="text-gray-400">"Quer me convidar para palestrar? Entre em contato!"</span>
+          <span className="animate-pulse">_</span>
+        </div>
       </div>
     </div>
   )
@@ -33,5 +233,4 @@ export const metadata: Metadata = {
   description: "Veja as palestras e apresentações que já fiz ao longo do tempo.",
 }
 
-
-export default Talks
+export default TalksPage

--- a/src/components/deck/Deck.tsx
+++ b/src/components/deck/Deck.tsx
@@ -1,6 +1,6 @@
 "use client"
 import React, { useCallback, useEffect, useRef, useState } from "react"
-import { ArrowRight, ArrowLeft } from 'lucide-react';
+import { ArrowRight, ArrowLeft, Maximize2, Minimize2, BookOpen, Home, Monitor } from 'lucide-react'
 
 /**
  * Deck
@@ -11,6 +11,7 @@ import { ArrowRight, ArrowLeft } from 'lucide-react';
  * - indicador de progresso
  *
  * Projetado para ser simples, acessível e fácil de estender.
+ * Design: Terminal/Código estético harmonizado com o site.
  */
 
 export type DeckProps = {
@@ -23,6 +24,7 @@ export type DeckProps = {
 export default function Deck({ slides, title, initial = 0, notes }: DeckProps) {
   const [index, setIndex] = useState<number>(initial)
   const [presenter, setPresenter] = useState<boolean>(false)
+  const [isFullscreen, setIsFullscreen] = useState<boolean>(false)
   const containerRef = useRef<HTMLDivElement | null>(null)
 
   // vai para o slide N (faz clamp)
@@ -34,6 +36,16 @@ export default function Deck({ slides, title, initial = 0, notes }: DeckProps) {
   const next = useCallback(() => goTo(index + 1), [goTo, index])
   const prev = useCallback(() => goTo(index - 1), [goTo, index])
 
+  const toggleFullscreen = useCallback(() => {
+    if (document.fullscreenElement) {
+      document.exitFullscreen()
+      setIsFullscreen(false)
+    } else {
+      containerRef.current?.requestFullscreen()
+      setIsFullscreen(true)
+    }
+  }, [])
+
   // handlers de teclado
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -44,21 +56,25 @@ export default function Deck({ slides, title, initial = 0, notes }: DeckProps) {
         e.preventDefault()
         prev()
       } else if (e.key === "f") {
-        // atalho para fullscreen
-        if (document.fullscreenElement) document.exitFullscreen()
-        else containerRef.current?.requestFullscreen()
+        toggleFullscreen()
       } else if (e.key === "p") {
-        // atalho para presenter notes
         setPresenter(v => !v)
       } else if (e.key === "h") {
-        // atalho para voltar a home
         window.location.href = "/"
       }
     }
 
+    function onFullscreenChange() {
+      setIsFullscreen(!!document.fullscreenElement)
+    }
+
     window.addEventListener("keydown", onKey)
-    return () => window.removeEventListener("keydown", onKey)
-    }, [next, prev])
+    document.addEventListener("fullscreenchange", onFullscreenChange)
+    return () => {
+      window.removeEventListener("keydown", onKey)
+      document.removeEventListener("fullscreenchange", onFullscreenChange)
+    }
+  }, [next, prev, toggleFullscreen])
 
   // suporte a swipe simples (mobile)
   useEffect(() => {
@@ -88,57 +104,173 @@ export default function Deck({ slides, title, initial = 0, notes }: DeckProps) {
   const progress = Math.round(((index + 1) / Math.max(1, slides.length)) * 100)
 
   return (
-    <div ref={containerRef} className="relative w-full min-h-[80vh] flex flex-col items-center justify-center">
-      {/* título da apresentação */}
-      {title ? (
-        <div className="absolute top-6 left-6 text-sm text-gray-300 select-none">{title}</div>
-      ) : null}
+    <div
+      ref={containerRef}
+      className={`relative w-full flex flex-col bg-[#111] ${isFullscreen ? 'h-screen' : 'min-h-[85vh]'}`}
+    >
+      {/* Terminal Window Container */}
+      <div className="flex-1 flex flex-col border border-gray-800/60 bg-[#161616] m-2 sm:m-4 overflow-hidden">
 
-      {/* área do slide */}
-      <div className="w-full max-w-7xl h-[60vh] md:h-[82vh]  p-6 flex items-center justify-center">
-        <div className="w-full h-full flex items-center justify-center text-white text-left">
-          {/* O slide atual é um ReactNode — permite MDX/JSX */}
-          <div className="w-full h-full flex items-center justify-center">
-            <div className="prose prose-invert max-w-none w-full">
+        {/* Terminal Header Bar */}
+        <div className="flex items-center justify-between px-4 py-2 border-b border-gray-800/60 bg-[#1a1a1a] flex-shrink-0">
+          <div className="flex items-center gap-3">
+            <div className="flex gap-1.5">
+              <button
+                onClick={() => window.location.href = "/"}
+                className="w-3 h-3 rounded-full bg-red-500/80 hover:bg-red-500 transition-colors"
+                title="Voltar ao início [h]"
+              />
+              <button
+                onClick={() => setPresenter(v => !v)}
+                className="w-3 h-3 rounded-full bg-yellow-500/80 hover:bg-yellow-500 transition-colors"
+                title="Notas do apresentador [p]"
+              />
+              <button
+                onClick={toggleFullscreen}
+                className="w-3 h-3 rounded-full bg-green-500/80 hover:bg-green-500 transition-colors"
+                title="Fullscreen [f]"
+              />
+            </div>
+            <span className="text-xs text-gray-400 font-mono hidden sm:inline">
+              ~/presentations/{title?.toLowerCase().replace(/\s+/g, '-').slice(0, 30) || 'deck'}
+            </span>
+          </div>
+
+          <div className="flex items-center gap-4">
+            {/* Slide Counter */}
+            <div className="flex items-center gap-2 text-xs text-gray-400 font-mono">
+              <Monitor className="w-3 h-3" />
+              <span>{index + 1}<span className="text-gray-600">/</span>{slides.length}</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Slide Area */}
+        <div className="flex-1 flex items-center justify-center p-4 sm:p-8 overflow-auto">
+          <div className="w-full max-w-6xl">
+            <div className="prose prose-invert prose-lg max-w-none">
               {slides[index]}
             </div>
           </div>
         </div>
-      </div>
 
-      {/* controles e progresso */}
-      <div className="w-full max-w-4xl mt-4 flex items-center justify-between gap-4">
-        <div className="flex items-center gap-2">
-          <button onClick={prev} aria-label="Anterior" className="px-3 py-1"><ArrowLeft size={16} /></button>
-          <button onClick={next} aria-label="Próximo" className="px-3 py-1"><ArrowRight size={16} /></button>
-          <button onClick={() =>  window.location.href = "/"} className="px-1 py-0.5 text-xs border border-gray-700">[h] home </button>
-          <button onClick={() => setPresenter(v => !v)} className="px-1 py-0.5 text-xs border border-gray-700">[p] notas </button>
-        </div>
+        {/* Controls Bar */}
+        <div className="flex items-center justify-between px-4 py-3 border-t border-gray-800/60 bg-[#1a1a1a] flex-shrink-0">
+          {/* Navigation Buttons */}
+          <div className="flex items-center gap-2">
+            <button
+              onClick={prev}
+              disabled={index === 0}
+              aria-label="Slide anterior"
+              className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-mono border transition-all duration-200 ${index === 0
+                  ? 'border-gray-800 text-gray-600 cursor-not-allowed'
+                  : 'border-gray-700 text-gray-400 hover:border-blue-400/50 hover:text-blue-400'
+                }`}
+            >
+              <ArrowLeft className="w-3 h-3" />
+              <span className="hidden sm:inline">prev</span>
+            </button>
+            <button
+              onClick={next}
+              disabled={index === slides.length - 1}
+              aria-label="Próximo slide"
+              className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-mono border transition-all duration-200 ${index === slides.length - 1
+                  ? 'border-gray-800 text-gray-600 cursor-not-allowed'
+                  : 'border-gray-700 text-gray-400 hover:border-blue-400/50 hover:text-blue-400'
+                }`}
+            >
+              <span className="hidden sm:inline">next</span>
+              <ArrowRight className="w-3 h-3" />
+            </button>
+          </div>
 
-        <div className="flex-1 px-4">
-          <div className="w-full h-0.5 bg-gray-800 overflow-hidden">
-            <div className="h-0.5 bg-blue-400" style={{ width: `${progress}%` }} />
+          {/* Progress Bar */}
+          <div className="flex-1 mx-4 max-w-md hidden sm:block">
+            <div className="relative w-full h-1 bg-gray-800 overflow-hidden">
+              <div
+                className="absolute left-0 top-0 h-full bg-gradient-to-r from-blue-500 to-blue-400 transition-all duration-300"
+                style={{ width: `${progress}%` }}
+              />
+            </div>
+            <div className="flex justify-between mt-1 text-[10px] text-gray-600 font-mono">
+              <span>0%</span>
+              <span>{progress}%</span>
+              <span>100%</span>
+            </div>
+          </div>
+
+          {/* Keyboard Shortcuts */}
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => window.location.href = "/"}
+              className="flex items-center gap-1 px-2 py-1 text-[10px] font-mono border border-gray-700/50 text-gray-500 hover:border-gray-600 hover:text-gray-400 transition-colors"
+              title="Voltar ao início"
+            >
+              <Home className="w-3 h-3" />
+              <span className="hidden sm:inline">h</span>
+            </button>
+            <button
+              onClick={() => setPresenter(v => !v)}
+              className={`flex items-center gap-1 px-2 py-1 text-[10px] font-mono border transition-colors ${presenter
+                  ? 'border-blue-400/50 text-blue-400 bg-blue-400/10'
+                  : 'border-gray-700/50 text-gray-500 hover:border-gray-600 hover:text-gray-400'
+                }`}
+              title="Notas do apresentador"
+            >
+              <BookOpen className="w-3 h-3" />
+              <span className="hidden sm:inline">p</span>
+            </button>
+            <button
+              onClick={toggleFullscreen}
+              className="flex items-center gap-1 px-2 py-1 text-[10px] font-mono border border-gray-700/50 text-gray-500 hover:border-gray-600 hover:text-gray-400 transition-colors"
+              title="Fullscreen"
+            >
+              {isFullscreen ? <Minimize2 className="w-3 h-3" /> : <Maximize2 className="w-3 h-3" />}
+              <span className="hidden sm:inline">f</span>
+            </button>
           </div>
         </div>
-
-        <div className="w-36 text-right text-xs text-gray-300">{index + 1} / {slides.length}</div>
       </div>
 
-      {/* painel do apresentador */}
-      {presenter ? (
-        <div className="w-full max-w-4xl mt-4 p-4 text-sm text-gray-200">
-          <div className="flex items-start justify-between">
-            <div className="max-w-[70%] pr-4">
-              <div className="font-semibold mb-2">Slide {index + 1}</div>
-              <div className="text-sm text-gray-300">{notes?.[index] ?? "— sem notas —"}</div>
+      {/* Presenter Notes Panel */}
+      {presenter && (
+        <div className="mx-2 sm:mx-4 mb-2 sm:mb-4 border border-gray-800/60 bg-[#161616] animate-fade-in-up">
+          {/* Notes Header */}
+          <div className="flex items-center justify-between px-4 py-2 border-b border-gray-800/60 bg-[#1a1a1a]">
+            <div className="flex items-center gap-2">
+              <BookOpen className="w-3.5 h-3.5 text-blue-400" />
+              <span className="text-xs text-gray-400 font-mono">presenter-notes.md</span>
             </div>
-            <div className="text-right">
-              <div className="text-xs text-gray-400">[p] notas / [f] fullscreen</div>
-              <div className="mt-2 text-sm">Progresso: {progress}%</div>
+            <button
+              onClick={() => setPresenter(false)}
+              className="text-xs text-gray-500 hover:text-white transition-colors"
+            >
+              [esc]
+            </button>
+          </div>
+
+          {/* Notes Content */}
+          <div className="p-4">
+            <div className="flex items-start gap-2 mb-3">
+              <span className="text-emerald-400 font-mono text-sm">❯</span>
+              <span className="text-gray-400 font-mono text-sm">cat</span>
+              <span className="text-white font-mono text-sm">slide-{index + 1}.md</span>
+            </div>
+            <div className="pl-5 border-l-2 border-gray-800 text-gray-300 text-sm leading-relaxed">
+              {notes?.[index] || (
+                <span className="text-gray-600 italic">— sem notas para este slide —</span>
+              )}
+            </div>
+
+            {/* Quick Stats */}
+            <div className="mt-4 pt-4 border-t border-gray-800/40 flex items-center gap-6 text-xs text-gray-500 font-mono">
+              <span>slide: {index + 1}/{slides.length}</span>
+              <span>progress: {progress}%</span>
+              <span>remaining: {slides.length - index - 1}</span>
             </div>
           </div>
         </div>
-      ) : null}
+      )}
     </div>
   )
 }

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -16,9 +16,9 @@ export function Header() {
               <span className="w-3 h-3 rounded-full bg-yellow-500/80" />
               <span className="w-3 h-3 rounded-full bg-green-500/80" />
             </div>
-            <span className="ml-3 text-xs text-gray-500 font-mono">zsh</span>
+            <span className="ml-3 text-xs text-gray-400 font-mono">zsh</span>
           </div>
-          <div className="flex items-center gap-2 text-xs text-gray-500 font-mono">
+          <div className="flex items-center gap-2 text-xs text-gray-400 font-mono">
             <span className="hidden sm:inline">~/Development/joaquimsnjr.tech</span>
             <span className="sm:hidden">~/joaquimsnjr.tech</span>
           </div>
@@ -76,7 +76,7 @@ export function Header() {
                 </div>
                 <div className="flex items-center gap-1.5">
                   <Coffee className="w-4 h-4 text-orange-400" />
-                  <span className="text-gray-500">Powered by coffee</span>
+                  <span className="text-gray-400">Powered by coffee</span>
                 </div>
               </div>
 
@@ -90,7 +90,7 @@ export function Header() {
           <div className="font-mono text-sm space-y-2 text-gray-400">
             <div className="flex items-start gap-2">
               <span className="text-emerald-400 select-none">❯</span>
-              <span className="text-gray-500">cat</span>
+              <span className="text-gray-400">cat</span>
               <span className="text-white">about.md</span>
             </div>
             <div className="pl-5 text-gray-300 leading-relaxed">
@@ -110,7 +110,7 @@ export function Header() {
               href="/projects"
               className="group flex items-center gap-2 px-4 py-2.5 bg-[#1a1a1a] border border-gray-800/60 hover:border-blue-400/50 transition-all duration-300"
             >
-              <Terminal className="w-4 h-4 text-gray-500 group-hover:text-blue-400 transition-colors" />
+              <Terminal className="w-4 h-4 text-gray-400 group-hover:text-blue-400 transition-colors" />
               <span className="text-sm text-gray-300 group-hover:text-white transition-colors">
                 projetos
               </span>
@@ -121,7 +121,7 @@ export function Header() {
               href="/talks"
               className="group flex items-center gap-2 px-4 py-2.5 bg-[#1a1a1a] border border-gray-800/60 hover:border-blue-400/50 transition-all duration-300"
             >
-              <span className="text-gray-500 group-hover:text-blue-400 transition-colors font-mono text-sm">[t]</span>
+              <span className="text-gray-400 group-hover:text-blue-400 transition-colors font-mono text-sm">[t]</span>
               <span className="text-sm text-gray-300 group-hover:text-white transition-colors">
                 talks
               </span>
@@ -134,7 +134,7 @@ export function Header() {
               rel="noopener noreferrer"
               className="group flex items-center gap-2 px-4 py-2.5 bg-[#1a1a1a] border border-gray-800/60 hover:border-blue-400/50 transition-all duration-300"
             >
-              <svg className="w-4 h-4 text-gray-500 group-hover:text-blue-400 transition-colors" fill="currentColor" viewBox="0 0 24 24">
+              <svg className="w-4 h-4 text-gray-400 group-hover:text-blue-400 transition-colors" fill="currentColor" viewBox="0 0 24 24">
                 <path fillRule="evenodd" clipRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
               </svg>
               <span className="text-sm text-gray-300 group-hover:text-white transition-colors">

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -93,7 +93,7 @@ export function Navbar() {
                   font-mono text-[10px] px-1.5 py-0.5 border
                   ${isActive(item.href)
                     ? "border-blue-400/30 text-blue-400 bg-blue-400/10"
-                    : "border-gray-700 text-gray-600 group-hover:border-gray-600 group-hover:text-gray-400"
+                    : "border-gray-700 text-gray-500 group-hover:border-gray-600 group-hover:text-gray-400"
                   }
                 `}>
                   {item.shortcut}
@@ -114,7 +114,7 @@ export function Navbar() {
           <div className="sm:hidden flex-1 px-4 py-3">
             <div className="flex items-center gap-2 text-gray-400 font-mono text-sm">
               <span className="text-emerald-400">❯</span>
-              <span className="text-gray-500">cd</span>
+              <span className="text-gray-400">cd</span>
               <span className="text-white">{pathname === "/" ? "~" : pathname}</span>
             </div>
           </div>
@@ -123,7 +123,7 @@ export function Navbar() {
         {/* Keyboard Shortcuts Toggle */}
         <button
           onClick={() => setShowShortcuts(!showShortcuts)}
-          className="hidden md:flex items-center gap-2 px-4 py-3 border-l border-gray-800/60 text-gray-500 hover:text-gray-300 hover:bg-[#1a1a1a] transition-all duration-200"
+          className="hidden md:flex items-center gap-2 px-4 py-3 border-l border-gray-800/60 text-gray-400 hover:text-gray-300 hover:bg-[#1a1a1a] transition-all duration-200"
           title="Keyboard shortcuts"
         >
           <Command className="w-4 h-4" />
@@ -135,7 +135,7 @@ export function Navbar() {
       {/* Keyboard Shortcuts Panel */}
       {showShortcuts && (
         <div className="mt-2 border border-gray-800/60 bg-[#161616] p-4 animate-fade-in-up">
-          <div className="flex items-center gap-2 mb-3 text-xs text-gray-500">
+          <div className="flex items-center gap-2 mb-3 text-xs text-gray-400">
             <Command className="w-3 h-3" />
             <span>Keyboard shortcuts</span>
           </div>
@@ -145,14 +145,14 @@ export function Navbar() {
                 <kbd className="px-2 py-1 bg-gray-800/50 border border-gray-700 text-gray-400 font-mono text-xs">
                   {item.shortcut}
                 </kbd>
-                <span className="text-gray-500 text-xs">{item.label}</span>
+                <span className="text-gray-400 text-xs">{item.label}</span>
               </div>
             ))}
             <div className="flex items-center gap-2">
               <kbd className="px-2 py-1 bg-gray-800/50 border border-gray-700 text-gray-400 font-mono text-xs">
                 t
               </kbd>
-              <span className="text-gray-500 text-xs">talks</span>
+              <span className="text-gray-400 text-xs">talks</span>
             </div>
           </div>
         </div>
@@ -169,7 +169,7 @@ export function Navbar() {
               transition-all duration-200
               ${isActive(item.href)
                 ? "bg-blue-400/10 border-blue-400/30 text-blue-400"
-                : "bg-[#161616] text-gray-500 hover:text-white hover:border-gray-700"
+                : "bg-[#161616] text-gray-400 hover:text-white hover:border-gray-700"
               }
             `}
           >

--- a/src/components/post-item.tsx
+++ b/src/components/post-item.tsx
@@ -51,8 +51,8 @@ export function PostItem({ post, isSelected, index = 0 }: PostItemProps) {
     <Link
       href={`/blog/${post.slug}`}
       className={`group block border transition-all duration-300 ${isSelected
-          ? 'border-blue-400/50 bg-blue-400/5'
-          : 'border-gray-800/60 bg-[#161616] hover:border-blue-400/50 hover:bg-[#1a1a1a]'
+        ? 'border-blue-400/50 bg-blue-400/5'
+        : 'border-gray-800/60 bg-[#161616] hover:border-blue-400/50 hover:bg-[#1a1a1a]'
         }`}
       aria-label={`Ler artigo: ${post.metadata.title}`}
     >
@@ -60,13 +60,13 @@ export function PostItem({ post, isSelected, index = 0 }: PostItemProps) {
       <div className="flex items-center justify-between px-4 py-2 border-b border-gray-800/40 bg-[#1a1a1a]">
         <div className="flex items-center gap-2">
           <div className="flex gap-1">
-            <span className="w-2 h-2 rounded-full bg-gray-600" />
-            <span className="w-2 h-2 rounded-full bg-gray-600" />
-            <span className="w-2 h-2 rounded-full bg-gray-600" />
+            <span className="w-2 h-2 rounded-full bg-gray-500" />
+            <span className="w-2 h-2 rounded-full bg-gray-500" />
+            <span className="w-2 h-2 rounded-full bg-gray-500" />
           </div>
-          <span className="text-[10px] text-gray-600 font-mono ml-2">posts/{post.slug.slice(0, 20)}...</span>
+          <span className="text-[10px] text-gray-500 font-mono ml-2">posts/{post.slug.slice(0, 20)}...</span>
         </div>
-        <span className="text-[10px] text-gray-600 font-mono">[{category}]</span>
+        <span className="text-[10px] text-gray-500 font-mono">[{category}]</span>
       </div>
 
       {/* Content */}
@@ -88,7 +88,7 @@ export function PostItem({ post, isSelected, index = 0 }: PostItemProps) {
         {/* Text Content */}
         <div className="flex-1 min-w-0">
           {/* Meta info */}
-          <div className="flex items-center gap-3 text-xs text-gray-500 mb-2">
+          <div className="flex items-center gap-3 text-xs text-gray-400 mb-2">
             <div className="flex items-center gap-1">
               <Calendar className="w-3 h-3" />
               <time dateTime={new Date(post.metadata.date).toISOString()}>
@@ -109,7 +109,7 @@ export function PostItem({ post, isSelected, index = 0 }: PostItemProps) {
 
           {/* Description */}
           {post.metadata.description && (
-            <p className="mt-2 text-sm text-gray-500 line-clamp-1">
+            <p className="mt-2 text-sm text-gray-400 line-clamp-1">
               {post.metadata.description}
             </p>
           )}
@@ -118,8 +118,8 @@ export function PostItem({ post, isSelected, index = 0 }: PostItemProps) {
         {/* Arrow indicator */}
         <div className="flex-shrink-0 self-center">
           <ArrowUpRight className={`w-5 h-5 transition-all duration-200 ${isSelected
-              ? 'text-blue-400'
-              : 'text-gray-700 group-hover:text-blue-400 group-hover:translate-x-0.5 group-hover:-translate-y-0.5'
+            ? 'text-blue-400'
+            : 'text-gray-500 group-hover:text-blue-400 group-hover:translate-x-0.5 group-hover:-translate-y-0.5'
             }`} />
         </div>
       </div>

--- a/src/components/posts.tsx
+++ b/src/components/posts.tsx
@@ -90,14 +90,14 @@ export function Posts({ posts }: PostsProps) {
                   <span className="w-3 h-3 rounded-full bg-yellow-500/80" />
                   <span className="w-3 h-3 rounded-full bg-green-500/80" />
                 </div>
-                <span className="ml-3 text-xs text-gray-500 font-mono">search</span>
+                <span className="ml-3 text-xs text-gray-400 font-mono">search</span>
               </div>
               <button
                 onClick={() => {
                   setIsSearching(false)
                   setSearchQuery("")
                 }}
-                className="text-gray-500 hover:text-white transition-colors"
+                className="text-gray-400 hover:text-white transition-colors"
               >
                 <X className="w-4 h-4" />
               </button>
@@ -106,12 +106,12 @@ export function Posts({ posts }: PostsProps) {
             {/* Search Input */}
             <div className="flex items-center gap-3 px-4 py-4 border-b border-gray-800/60">
               <span className="text-emerald-400 font-mono">❯</span>
-              <span className="text-gray-500 font-mono text-sm">grep</span>
+              <span className="text-gray-400 font-mono text-sm">grep</span>
               <input
                 type="text"
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                className="flex-1 bg-transparent outline-none text-white font-mono placeholder:text-gray-600"
+                className="flex-1 bg-transparent outline-none text-white font-mono placeholder:text-gray-500"
                 autoFocus
                 placeholder="buscar artigos..."
                 aria-label="Search posts"
@@ -127,7 +127,7 @@ export function Posts({ posts }: PostsProps) {
             </div>
 
             {/* Results Count */}
-            <div className="px-4 py-2 text-xs text-gray-600 font-mono border-b border-gray-800/40">
+            <div className="px-4 py-2 text-xs text-gray-500 font-mono border-b border-gray-800/40">
               {filteredPosts.length} resultado{filteredPosts.length !== 1 ? 's' : ''} encontrado{filteredPosts.length !== 1 ? 's' : ''}
             </div>
 
@@ -139,8 +139,8 @@ export function Posts({ posts }: PostsProps) {
                     key={item.slug}
                     onClick={() => router.push(`/blog/${item.slug}`)}
                     className={`w-full text-left px-4 py-3 flex items-center gap-3 transition-colors ${index === selectedIndex
-                        ? 'bg-blue-400/10 border-l-2 border-blue-400'
-                        : 'hover:bg-gray-800/30 border-l-2 border-transparent'
+                      ? 'bg-blue-400/10 border-l-2 border-blue-400'
+                      : 'hover:bg-gray-800/30 border-l-2 border-transparent'
                       }`}
                   >
                     <div className="flex-1 min-w-0">
@@ -148,12 +148,12 @@ export function Posts({ posts }: PostsProps) {
                         }`}>
                         {item.metadata.title}
                       </p>
-                      <p className="text-xs text-gray-600 truncate mt-0.5">
+                      <p className="text-xs text-gray-500 truncate mt-0.5">
                         {item.metadata.description}
                       </p>
                     </div>
                     {index === selectedIndex && (
-                      <div className="flex items-center gap-1 text-gray-600">
+                      <div className="flex items-center gap-1 text-gray-500">
                         <CornerDownLeft className="w-3 h-3" />
                         <span className="text-[10px]">enter</span>
                       </div>
@@ -162,14 +162,14 @@ export function Posts({ posts }: PostsProps) {
                 ))
               ) : (
                 <div className="px-4 py-8 text-center">
-                  <p className="text-gray-600 font-mono text-sm">Nenhum artigo encontrado</p>
-                  <p className="text-gray-700 text-xs mt-1">Tente outro termo de busca</p>
+                  <p className="text-gray-500 font-mono text-sm">Nenhum artigo encontrado</p>
+                  <p className="text-gray-500 text-xs mt-1">Tente outro termo de busca</p>
                 </div>
               )}
             </div>
 
             {/* Footer */}
-            <div className="flex items-center justify-between px-4 py-2 border-t border-gray-800/60 bg-[#1a1a1a] text-xs text-gray-600">
+            <div className="flex items-center justify-between px-4 py-2 border-t border-gray-800/60 bg-[#1a1a1a] text-xs text-gray-500">
               <div className="flex items-center gap-4">
                 <div className="flex items-center gap-1">
                   <kbd className="px-1.5 py-0.5 bg-gray-800 border border-gray-700 text-[10px]">↑↓</kbd>

--- a/src/components/projects-section.tsx
+++ b/src/components/projects-section.tsx
@@ -90,7 +90,7 @@ function ProjectCard({ project, index }: ProjectCardProps) {
           </div>
 
           {/* Título no estilo path */}
-          <span className="text-xs text-gray-500">
+          <span className="text-xs text-gray-400">
             ~/projects/{project.slug}
           </span>
         </div>
@@ -113,14 +113,14 @@ function ProjectCard({ project, index }: ProjectCardProps) {
             <h3 className="text-lg font-semibold text-white transition-colors duration-200 group-hover:text-blue-400">
               {project.title}
             </h3>
-            <p className="text-xs text-gray-500">{project.role}</p>
+            <p className="text-xs text-gray-400">{project.role}</p>
           </div>
         </div>
 
         {/* Descrição estilo código */}
         <div className="mb-5 border-l-2 border-gray-700/50 pl-3">
           <p className="text-sm leading-relaxed text-gray-400">
-            <span className="text-gray-600">// </span>
+            <span className="text-gray-500">// </span>
             {project.description}
           </p>
         </div>
@@ -137,7 +137,7 @@ function ProjectCard({ project, index }: ProjectCardProps) {
               </span>
             ))}
             {project.technologies.length > 5 && (
-              <span className="px-2 py-0.5 text-[11px] text-gray-600">
+              <span className="px-2 py-0.5 text-[11px] text-gray-500">
                 +{project.technologies.length - 5}
               </span>
             )}
@@ -200,7 +200,7 @@ function FeaturedProject({ project }: FeaturedProjectProps) {
             <span className="h-3 w-3 rounded-full bg-yellow-500/70" />
             <span className="h-3 w-3 rounded-full bg-green-500/70" />
           </div>
-          <span className="font-mono text-xs text-gray-500">
+          <span className="font-mono text-xs text-gray-400">
             ~/projects/{project.slug} — zsh
           </span>
         </div>
@@ -223,7 +223,7 @@ function FeaturedProject({ project }: FeaturedProjectProps) {
               <h3 className="text-xl font-semibold text-white transition-colors duration-200 group-hover:text-blue-400">
                 {project.title}
               </h3>
-              <p className="text-sm text-gray-500">{project.role}</p>
+              <p className="text-sm text-gray-400">{project.role}</p>
             </div>
           </div>
 
@@ -261,7 +261,7 @@ function FeaturedProject({ project }: FeaturedProjectProps) {
 
         {/* Coluna direita: Techs estilo código */}
         <div className="border border-gray-800/40 bg-[#111] p-4">
-          <div className="mb-3 flex items-center gap-2 text-xs text-gray-500">
+          <div className="mb-3 flex items-center gap-2 text-xs text-gray-400">
             <Terminal className="h-3.5 w-3.5" />
             <span>stack.config</span>
           </div>


### PR DESCRIPTION
… aesthetic

Talks Page (/talks):
- Add terminal window header with macOS dots
- Implement status badges (palestra/workshop/lightning)
- Add meta information with icons (Calendar, MapPin, Users)
- Create section separation (upcoming vs past talks)
- Add pulsing indicator for upcoming events

Projects Page (/projects):
- Add terminal window header with project counter
- Implement FeaturedProject component with JSON-style stack config
- Add ProjectCard with status indicators (online/dev/archived)
- Create tech tags with hover effects
- Add action links (view project, source code)

Presentations System:
- Redesign Deck component with full terminal aesthetic
- Add interactive macOS dots (home/notes/fullscreen)
- Implement progress bar with gradient
- Add presenter notes panel with terminal styling
- Create keyboard shortcuts display (h/p/f)
- Add loading and error states with terminal style
- Implement fullscreen support with indicator

All changes follow:
- Consistent color contrast (WCAG AA compliant)
- Terminal/developer aesthetic matching site identity
- Responsive design patterns
- Smooth transitions and hover effects