### PR TITLE
feat(seo): complete metadata, custom 404 page and sitemap

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -89,12 +89,29 @@ export default async function BlogPage() {
 
 export const metadata: Metadata = {
   title: "Blog",
-  description: "Conteúdos sobre programação, engenharia de software e assuntos relacionados.",
+  description: "Artigos sobre engenharia de software, Cloud Native, Go e sistemas distribuídos. Compartilhando conhecimento e experiências.",
+  keywords: ["blog", "artigos", "Go", "Golang", "Cloud Native", "Kubernetes", "engenharia de software", "SRE"],
   openGraph: {
+    title: "Blog | Joaquim Silva",
+    description: "Artigos sobre engenharia de software, Cloud Native, Go e sistemas distribuídos.",
+    url: "https://www.joaquimsnjr.tech/blog",
+    siteName: "Joaquim Silva",
+    locale: "pt_BR",
+    type: "website",
     images: [
       {
         url: "https://www.joaquimsnjr.tech/og/home?title=blog",
+        width: 1200,
+        height: 630,
+        alt: "Blog - Joaquim Silva",
       },
     ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Blog | Joaquim Silva",
+    description: "Artigos sobre engenharia de software, Cloud Native, Go e sistemas distribuídos.",
+    creator: "@joaquimsnjunior",
+    images: ["https://www.joaquimsnjr.tech/og/home?title=blog"],
   },
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,34 +1,143 @@
 import Link from "next/link"
+import { Metadata } from "next"
+import { Home, ArrowLeft, Search, Terminal } from "lucide-react"
+
+export const metadata: Metadata = {
+  title: "404 - Página não encontrada",
+  description: "A página que você está procurando não foi encontrada.",
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
 
 export default function NotFound() {
   return (
-    <div className="flex items-center justify-center">
-      <div className="space-y-6 text-center">
-        <pre className="font-mono text-blue-400 whitespace-pre">
-          {`
-       _             _            _           
-   _  /\\ \\         / /\\       _  /\\ \\         
-  /\\_\\\\ \\ \\       / /  \\     /\\_\\\\ \\ \\        
- / / / \\ \\ \\     / / /\\ \\   / / / \\ \\ \\       
-/ / /   \\ \\ \\   / / /\\ \\ \\ / / /   \\ \\ \\      
-\\ \\ \\____\\ \\ \\ /_/ /  \\ \\ \\\\ \\ \\____\\ \\ \\     
- \\ \\________\\ \\\\ \\ \\   \\ \\ \\\\ \\________\\ \\    
-  \\/________/\\ \\\\ \\ \\   \\ \\ \\/________/\\ \\   
-            \\ \\ \\\\ \\ \\___\\ \\ \\         \\ \\ \\  
-             \\ \\_\\\\ \\/____\\ \\ \\         \\ \\_\\ 
-              \\/_/ \\_________\\/          \\/_/ 
-                                              
-          `}
-        </pre>
-        <p className="text-gray-400">
-          Não foi possível encontrar a página que você está procurando.
-        </p>
-        <Link
-          href="/"
-          className="inline-block text-gray-400 hover:text-blue-400 transition-colors"
-        >
-          voltar para a página inicial
-        </Link>
+    <div className="min-h-[80vh] flex items-center justify-center p-4">
+      <div className="w-full max-w-2xl animate-fade-in-up">
+        {/* Terminal Window */}
+        <div className="border border-gray-800/60 bg-[#161616]">
+          {/* Terminal Header */}
+          <div className="flex items-center justify-between px-4 py-3 border-b border-gray-800/60 bg-[#1a1a1a]">
+            <div className="flex items-center gap-2">
+              <div className="flex gap-1.5">
+                <span className="w-3 h-3 rounded-full bg-red-500/80" />
+                <span className="w-3 h-3 rounded-full bg-yellow-500/80" />
+                <span className="w-3 h-3 rounded-full bg-green-500/80" />
+              </div>
+              <span className="ml-3 text-xs text-gray-400 font-mono">~/404 — bash</span>
+            </div>
+            <div className="flex items-center gap-2 text-xs text-gray-500 font-mono">
+              <Terminal className="w-3 h-3" />
+              <span>error</span>
+            </div>
+          </div>
+
+          {/* Terminal Content */}
+          <div className="p-6 space-y-4 font-mono text-sm">
+            {/* Command */}
+            <div className="flex items-start gap-2">
+              <span className="text-emerald-400 select-none">❯</span>
+              <span className="text-gray-400">cat</span>
+              <span className="text-white">./requested-page</span>
+            </div>
+
+            {/* Error Output */}
+            <div className="pl-5 space-y-2">
+              <div className="text-red-400 flex items-center gap-2">
+                <span>✗</span>
+                <span>cat: ./requested-page: No such file or directory</span>
+              </div>
+            </div>
+
+            {/* ASCII Art 404 */}
+            <div className="py-6">
+              <pre className="text-blue-400 text-center text-xs sm:text-sm leading-tight">
+                {`
+ ██╗  ██╗ ██████╗ ██╗  ██╗
+ ██║  ██║██╔═══██╗██║  ██║
+ ███████║██║   ██║███████║
+ ╚════██║██║   ██║╚════██║
+      ██║╚██████╔╝     ██║
+      ╚═╝ ╚═════╝      ╚═╝
+`}
+              </pre>
+            </div>
+
+            {/* Error Message */}
+            <div className="border-l-2 border-red-500/30 pl-4 py-2">
+              <p className="text-gray-300">
+                <span className="text-red-400 font-semibold">Error:</span> A página que você está procurando não existe ou foi movida.
+              </p>
+              <p className="text-gray-500 text-xs mt-2">
+                Código de status: <span className="text-gray-400">404 NOT_FOUND</span>
+              </p>
+            </div>
+
+            {/* Suggestions */}
+            <div className="mt-6 space-y-2">
+              <div className="flex items-start gap-2">
+                <span className="text-emerald-400 select-none">❯</span>
+                <span className="text-gray-400">echo</span>
+                <span className="text-gray-300">"Talvez você queira:"</span>
+              </div>
+
+              <div className="pl-5 space-y-3 mt-4">
+                <Link
+                  href="/"
+                  className="group flex items-center gap-3 p-3 border border-gray-800/60 bg-[#1a1a1a] hover:border-blue-400/50 hover:bg-[#1a1a1a] transition-all duration-300"
+                >
+                  <div className="flex h-8 w-8 items-center justify-center border border-gray-700/50 bg-gray-800/30 text-blue-400 group-hover:border-blue-400/50">
+                    <Home className="h-4 w-4" />
+                  </div>
+                  <div>
+                    <p className="text-sm text-gray-300 group-hover:text-white transition-colors">
+                      Ir para a página inicial
+                    </p>
+                    <p className="text-xs text-gray-500">cd ~/home</p>
+                  </div>
+                </Link>
+
+                <Link
+                  href="/blog"
+                  className="group flex items-center gap-3 p-3 border border-gray-800/60 bg-[#1a1a1a] hover:border-blue-400/50 hover:bg-[#1a1a1a] transition-all duration-300"
+                >
+                  <div className="flex h-8 w-8 items-center justify-center border border-gray-700/50 bg-gray-800/30 text-blue-400 group-hover:border-blue-400/50">
+                    <Search className="h-4 w-4" />
+                  </div>
+                  <div>
+                    <p className="text-sm text-gray-300 group-hover:text-white transition-colors">
+                      Explorar o blog
+                    </p>
+                    <p className="text-xs text-gray-500">ls ~/blog</p>
+                  </div>
+                </Link>
+              </div>
+            </div>
+
+            {/* Footer Prompt */}
+            <div className="mt-6 pt-4 border-t border-gray-800/40">
+              <div className="flex items-center gap-2">
+                <span className="text-emerald-400 select-none">❯</span>
+                <Link
+                  href="/"
+                  className="text-gray-400 hover:text-blue-400 transition-colors flex items-center gap-2"
+                >
+                  <ArrowLeft className="w-3 h-3" />
+                  <span>cd ..</span>
+                </Link>
+                <span className="animate-pulse text-gray-400">_</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Glitch Effect Text */}
+        <div className="mt-6 text-center">
+          <p className="text-xs text-gray-600 font-mono">
+            process exited with code <span className="text-red-400">1</span>
+          </p>
+        </div>
       </div>
     </div>
   )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,42 @@
 import { Header } from "@/components/header"
 import { BlogSection } from "@/components/blog-section"
 import { ProjectsSection, type Project } from "@/components/projects-section"
-import { Navbar } from '../components/navbar';
-import { Footer } from "@/components/footer";
+import { Navbar } from '../components/navbar'
+import { Footer } from "@/components/footer"
+import { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: {
+    absolute: "~/Joaquim_Silva | SRE & Software Engineer",
+  },
+  description: "Engenheiro de Software & SRE focado em Cloud Native, Go e Kubernetes. Construindo infraestrutura que não dorme.",
+  keywords: ["SRE", "Software Engineer", "Go", "Golang", "Kubernetes", "Cloud Native", "DevOps", "AWS"],
+  authors: [{ name: "Joaquim Silva", url: "https://joaquimsnjr.tech" }],
+  creator: "Joaquim Silva",
+  openGraph: {
+    title: "Joaquim Silva | SRE & Software Engineer",
+    description: "Engenheiro de Software & SRE focado em Cloud Native, Go e Kubernetes. Construindo infraestrutura que não dorme.",
+    url: "https://www.joaquimsnjr.tech",
+    siteName: "Joaquim Silva",
+    locale: "pt_BR",
+    type: "website",
+    images: [
+      {
+        url: "https://www.joaquimsnjr.tech/og/home",
+        width: 1200,
+        height: 630,
+        alt: "Joaquim Silva - SRE & Software Engineer",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Joaquim Silva | SRE & Software Engineer",
+    description: "Engenheiro de Software & SRE focado em Cloud Native, Go e Kubernetes.",
+    creator: "@joaquimsnjunior",
+    images: ["https://www.joaquimsnjr.tech/og/home"],
+  },
+}
 
 const projects: Project[] = [
   {

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -387,12 +387,29 @@ export default function ProjectsPage() {
 
 export const metadata: Metadata = {
   title: "Projetos",
-  description: "Alguns dos projetos em que trabalhei.",
+  description: "Projetos de código aberto e ferramentas que desenvolvo. Construindo soluções com Go, TypeScript, Kubernetes e muito mais.",
+  keywords: ["projetos", "projects", "open source", "Go", "TypeScript", "Kubernetes", "portfolio"],
   openGraph: {
+    title: "Projetos | Joaquim Silva",
+    description: "Projetos de código aberto e ferramentas que desenvolvo. Construindo soluções com Go, TypeScript, Kubernetes e muito mais.",
+    url: "https://www.joaquimsnjr.tech/projects",
+    siteName: "Joaquim Silva",
+    locale: "pt_BR",
+    type: "website",
     images: [
       {
         url: "https://www.joaquimsnjr.tech/og/home?title=projects",
+        width: 1200,
+        height: 630,
+        alt: "Projetos - Joaquim Silva",
       },
     ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Projetos | Joaquim Silva",
+    description: "Projetos de código aberto e ferramentas que desenvolvo.",
+    creator: "@joaquimsnjunior",
+    images: ["https://www.joaquimsnjr.tech/og/home?title=projects"],
   },
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,43 +1,50 @@
+import { MetadataRoute } from "next"
 import { getPosts } from "@/lib/blog"
 
-const BASE_URL = "https://joaquimsnjr.tech"
+const BASE_URL = "https://www.joaquimsnjr.tech"
 
-export default async function sitemap() {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   // Buscar todos os posts do blog
-  const posts = await getPosts()
+  const posts = getPosts()
 
   // Gerar entries para cada post
-  const blogEntries = posts.map((post) => ({
+  const blogEntries: MetadataRoute.Sitemap = posts.map((post) => ({
     url: `${BASE_URL}/blog/${post.slug}`,
     lastModified: new Date(post.metadata.date),
-    changeFrequency: "monthly" as const,
+    changeFrequency: "monthly",
     priority: 0.8,
   }))
 
   // Páginas estáticas do site
-  const staticPages = [
+  const staticPages: MetadataRoute.Sitemap = [
     {
       url: BASE_URL,
       lastModified: new Date(),
-      changeFrequency: "weekly" as const,
+      changeFrequency: "weekly",
       priority: 1.0,
     },
     {
       url: `${BASE_URL}/blog`,
       lastModified: new Date(),
-      changeFrequency: "daily" as const,
+      changeFrequency: "daily",
       priority: 0.9,
+    },
+    {
+      url: `${BASE_URL}/projects`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.8,
     },
     {
       url: `${BASE_URL}/sobre`,
       lastModified: new Date(),
-      changeFrequency: "monthly" as const,
+      changeFrequency: "monthly",
       priority: 0.7,
     },
     {
       url: `${BASE_URL}/talks`,
       lastModified: new Date(),
-      changeFrequency: "monthly" as const,
+      changeFrequency: "monthly",
       priority: 0.7,
     },
   ]

--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -219,7 +219,31 @@ function SobrePage() {
 
 export const metadata: Metadata = {
   title: "Sobre mim",
-  description: "Conheça mais sobre minha trajetória como Engenheiro de Software & SRE.",
+  description: "Engenheiro de Software & SRE focado em Cloud Native, Go e Kubernetes. Conheça minha trajetória e experiência profissional.",
+  keywords: ["sobre", "about", "Joaquim Silva", "SRE", "Software Engineer", "experiência", "carreira"],
+  openGraph: {
+    title: "Sobre mim | Joaquim Silva",
+    description: "Engenheiro de Software & SRE focado em Cloud Native, Go e Kubernetes. Conheça minha trajetória e experiência profissional.",
+    url: "https://www.joaquimsnjr.tech/sobre",
+    siteName: "Joaquim Silva",
+    locale: "pt_BR",
+    type: "profile",
+    images: [
+      {
+        url: "https://www.joaquimsnjr.tech/og/home?title=sobre",
+        width: 1200,
+        height: 630,
+        alt: "Sobre mim - Joaquim Silva",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Sobre mim | Joaquim Silva",
+    description: "Engenheiro de Software & SRE focado em Cloud Native, Go e Kubernetes.",
+    creator: "@joaquimsnjunior",
+    images: ["https://www.joaquimsnjr.tech/og/home?title=sobre"],
+  },
 }
 
 export default SobrePage

--- a/src/app/talks/page.tsx
+++ b/src/app/talks/page.tsx
@@ -230,7 +230,31 @@ function TalksPage() {
 
 export const metadata: Metadata = {
   title: "Palestras & Apresentações",
-  description: "Veja as palestras e apresentações que já fiz ao longo do tempo.",
+  description: "Palestras sobre Cloud Native, Go, SRE e Open Source. Compartilhando conhecimento e conectando comunidades.",
+  keywords: ["palestras", "talks", "apresentações", "Go", "Cloud Native", "SRE", "Open Source"],
+  openGraph: {
+    title: "Palestras & Apresentações | Joaquim Silva",
+    description: "Palestras sobre Cloud Native, Go, SRE e Open Source. Compartilhando conhecimento e conectando comunidades.",
+    url: "https://www.joaquimsnjr.tech/talks",
+    siteName: "Joaquim Silva",
+    locale: "pt_BR",
+    type: "website",
+    images: [
+      {
+        url: "https://www.joaquimsnjr.tech/og/home?title=talks",
+        width: 1200,
+        height: 630,
+        alt: "Palestras & Apresentações - Joaquim Silva",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Palestras & Apresentações | Joaquim Silva",
+    description: "Palestras sobre Cloud Native, Go, SRE e Open Source.",
+    creator: "@joaquimsnjunior",
+    images: ["https://www.joaquimsnjr.tech/og/home?title=talks"],
+  },
 }
 
 export default TalksPage


### PR DESCRIPTION
Metadata Improvements:
- Add complete OpenGraph tags to all pages (url, siteName, locale, type)
- Add Twitter Cards configuration with creator handle
- Add keywords meta tags for SEO optimization
- Add authors and creator metadata to homepage
- Set noindex/nofollow for 404 page

Custom 404 Page:
- Redesign with terminal aesthetic matching site identity
- Add ASCII art '404' display
- Add simulated shell commands (cat, echo)
- Add navigation cards to Home and Blog
- Add animated cursor and exit code footer

Sitemap:
- Add proper TypeScript typing with MetadataRoute.Sitemap
- Add missing /projects page
- Fix BASE_URL to use www subdomain
- Remove unnecessary await from getPosts()

Files modified:
- src/app/page.tsx
- src/app/blog/page.tsx
- src/app/projects/page.tsx
- src/app/sobre/page.tsx
- src/app/talks/page.tsx
- src/app/not-found.tsx
- src/app/sitemap.ts