### PR TITLE
feat(seo): add JSON-LD structured data and RSS feed

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -10,8 +10,36 @@ const posts = getPosts().sort(
 )
 
 export default async function BlogPage() {
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Blog",
+    name: "Blog | Joaquim Silva",
+    description: "Artigos sobre engenharia de software, Cloud Native, Go e sistemas distribuídos.",
+    url: "https://www.joaquimsnjr.tech/blog",
+    author: {
+      "@type": "Person",
+      name: "Joaquim Silva",
+      url: "https://www.joaquimsnjr.tech",
+    },
+    blogPost: posts.slice(0, 10).map((post) => ({
+      "@type": "BlogPosting",
+      headline: post.metadata.title,
+      description: post.metadata.description,
+      datePublished: post.metadata.date,
+      url: `https://www.joaquimsnjr.tech/blog/${post.slug}`,
+      author: {
+        "@type": "Person",
+        name: "Joaquim Silva",
+      },
+    })),
+  }
+
   return (
     <main className="animate-fade-in-up relative">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       {/* Terminal Window Header */}
       <div className="border border-gray-800/60 bg-[#161616] mb-8">
         {/* Terminal Bar */}

--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -1,0 +1,61 @@
+import { getPosts } from "@/lib/blog"
+
+const SITE_URL = "https://www.joaquimsnjr.tech"
+
+export async function GET() {
+  const posts = getPosts().sort(
+    (a, b) =>
+      new Date(b.metadata.date).getTime() - new Date(a.metadata.date).getTime()
+  )
+
+  const feedItems = posts
+    .map((post) => {
+      const pubDate = new Date(post.metadata.date).toUTCString()
+      const link = `${SITE_URL}/blog/${post.slug}`
+
+      return `
+    <item>
+      <title><![CDATA[${post.metadata.title}]]></title>
+      <link>${link}</link>
+      <guid isPermaLink="true">${link}</guid>
+      <description><![CDATA[${post.metadata.description || ""}]]></description>
+      <pubDate>${pubDate}</pubDate>
+      <author>joaquimsnjunior@gmail.com (Joaquim Silva)</author>
+      ${post.metadata.coverImage ? `<enclosure url="${post.metadata.coverImage}" type="image/jpeg" />` : ""}
+    </item>`
+    })
+    .join("")
+
+  const feed = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <title>Joaquim Silva | Blog</title>
+    <link>${SITE_URL}</link>
+    <description>Artigos sobre engenharia de software, Cloud Native, Go e sistemas distribuídos.</description>
+    <language>pt-BR</language>
+    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+    <atom:link href="${SITE_URL}/feed.xml" rel="self" type="application/rss+xml"/>
+    <image>
+      <url>https://res.cloudinary.com/dy5xyare1/image/upload/v1764384343/ProfileBW_jddt02.png</url>
+      <title>Joaquim Silva | Blog</title>
+      <link>${SITE_URL}</link>
+    </image>
+    <copyright>© ${new Date().getFullYear()} Joaquim Silva. Todos os direitos reservados.</copyright>
+    <managingEditor>joaquimsnjunior@gmail.com (Joaquim Silva)</managingEditor>
+    <webMaster>joaquimsnjunior@gmail.com (Joaquim Silva)</webMaster>
+    <category>Technology</category>
+    <category>Software Engineering</category>
+    <category>Cloud Native</category>
+    <category>Go</category>
+    <ttl>60</ttl>
+    ${feedItems}
+  </channel>
+</rss>`
+
+  return new Response(feed, {
+    headers: {
+      "Content-Type": "application/xml; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, s-maxage=3600",
+    },
+  })
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,6 +37,12 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     creator: "@joaquimsnjunior",
   },
+  alternates: {
+    canonical: "https://www.joaquimsnjr.tech",
+    types: {
+      "application/rss+xml": "https://www.joaquimsnjr.tech/feed.xml",
+    },
+  },
 }
 
 export default function RootLayout({
@@ -44,8 +50,62 @@ export default function RootLayout({
 }: {
   children: React.ReactNode
 }) {
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: "Joaquim Silva",
+    url: "https://www.joaquimsnjr.tech",
+    image: "https://res.cloudinary.com/dy5xyare1/image/upload/v1764384343/ProfileBW_jddt02.png",
+    sameAs: [
+      "https://github.com/joaquimsnjunior",
+      "https://twitter.com/joaquimsnjunior",
+      "https://linkedin.com/in/joaquimsnjunior",
+    ],
+    jobTitle: "SRE & Software Engineer",
+    worksFor: {
+      "@type": "Organization",
+      name: "All Net Educação",
+    },
+    knowsAbout: ["Go", "Kubernetes", "Cloud Native", "AWS", "SRE", "DevOps"],
+    alumniOf: {
+      "@type": "Organization",
+      name: "ETEC",
+    },
+  }
+
+  const websiteJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: "Joaquim Silva",
+    alternateName: "joaquimsnjr.tech",
+    url: "https://www.joaquimsnjr.tech",
+    description: "Blog pessoal sobre engenharia de software, Cloud Native, Go e sistemas distribuídos.",
+    author: {
+      "@type": "Person",
+      name: "Joaquim Silva",
+    },
+    potentialAction: {
+      "@type": "SearchAction",
+      target: {
+        "@type": "EntryPoint",
+        urlTemplate: "https://www.joaquimsnjr.tech/blog?q={search_term_string}",
+      },
+      "query-input": "required name=search_term_string",
+    },
+  }
+
   return (
     <html lang="pt-BR">
+      <head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }}
+        />
+      </head>
       <body
         className={`${geistMono.variable} antialiased min-h-screen font-mono overflow-x-hidden`}
       >

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -54,8 +54,31 @@ const projects: Project[] = [
 ]
 
 export default function HomePage() {
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "ProfilePage",
+    mainEntity: {
+      "@type": "Person",
+      name: "Joaquim Silva",
+      alternateName: "joaquimsnjunior",
+      description: "Engenheiro de Software & SRE focado em Cloud Native, Go e Kubernetes.",
+      image: "https://res.cloudinary.com/dy5xyare1/image/upload/v1764384343/ProfileBW_jddt02.png",
+      url: "https://www.joaquimsnjr.tech",
+      sameAs: [
+        "https://github.com/joaquimsnjunior",
+        "https://twitter.com/joaquimsnjunior",
+      ],
+      jobTitle: "SRE & Software Engineer",
+      knowsAbout: ["Go", "Kubernetes", "Cloud Native", "AWS", "Terraform", "Docker"],
+    },
+  }
+
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <Navbar />
       <Header />
       <BlogSection />

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -298,8 +298,43 @@ export default function ProjectsPage() {
   const featuredProjects = projects.filter(p => p.featured)
   const otherProjects = projects.filter(p => !p.featured)
 
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "Projetos",
+    description: "Projetos de código aberto e ferramentas desenvolvidas por Joaquim Silva.",
+    url: "https://www.joaquimsnjr.tech/projects",
+    author: {
+      "@type": "Person",
+      name: "Joaquim Silva",
+    },
+    mainEntity: {
+      "@type": "ItemList",
+      itemListElement: projects.map((project, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        item: {
+          "@type": "SoftwareSourceCode",
+          name: project.title,
+          description: project.description,
+          url: project.href,
+          codeRepository: project.github,
+          programmingLanguage: project.technologies,
+          author: {
+            "@type": "Person",
+            name: "Joaquim Silva",
+          },
+        },
+      })),
+    },
+  }
+
   return (
     <main className="animate-fade-in-up">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       {/* Terminal Window Header */}
       <div className="border border-gray-800/60 bg-[#161616] mb-8">
         {/* Terminal Bar */}

--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -49,8 +49,45 @@ const skills = [
 ]
 
 function SobrePage() {
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "AboutPage",
+    mainEntity: {
+      "@type": "Person",
+      name: "Joaquim Silva",
+      jobTitle: "SRE & Software Engineer",
+      description: "Engenheiro de Software & SRE focado em Cloud Native, Go e Kubernetes. Especialista em projetar sistemas de alto volume onde disponibilidade e performance são inegociáveis.",
+      image: "https://res.cloudinary.com/dy5xyare1/image/upload/v1764384343/ProfileBW_jddt02.png",
+      url: "https://www.joaquimsnjr.tech",
+      sameAs: [
+        "https://github.com/joaquimsnjunior",
+        "https://twitter.com/joaquimsnjunior",
+      ],
+      knowsAbout: ["Go", "TypeScript", "Python", "AWS", "Kubernetes", "Docker", "Terraform", "PostgreSQL", "Redis"],
+      worksFor: {
+        "@type": "Organization",
+        name: "All Net Educação",
+        url: "https://allneteducacao.com.br/",
+      },
+      hasOccupation: [
+        {
+          "@type": "Occupation",
+          name: "Educador & Mentor Técnico",
+          occupationLocation: {
+            "@type": "City",
+            name: "São Paulo",
+          },
+        },
+      ],
+    },
+  }
+
   return (
     <div className="animate-fade-in-up">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       {/* Terminal Window - About Header */}
       <div className="border border-gray-800/60 bg-[#161616] mb-8">
         {/* Terminal Bar */}

--- a/src/app/talks/page.tsx
+++ b/src/app/talks/page.tsx
@@ -139,8 +139,52 @@ function TalksPage() {
   const upcomingTalks = talks.filter(t => t.status === 'upcoming')
   const pastTalks = talks.filter(t => t.status === 'past')
 
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "Palestras & Apresentações",
+    description: "Palestras sobre Cloud Native, Go, SRE e Open Source.",
+    url: "https://www.joaquimsnjr.tech/talks",
+    author: {
+      "@type": "Person",
+      name: "Joaquim Silva",
+    },
+    mainEntity: {
+      "@type": "ItemList",
+      itemListElement: talks.map((talk, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        item: {
+          "@type": "Event",
+          name: talk.title,
+          description: talk.description,
+          eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
+          eventStatus: talk.status === 'upcoming'
+            ? "https://schema.org/EventScheduled"
+            : "https://schema.org/EventCompleted",
+          location: {
+            "@type": "Place",
+            name: talk.location,
+          },
+          organizer: {
+            "@type": "Organization",
+            name: talk.event,
+          },
+          performer: {
+            "@type": "Person",
+            name: "Joaquim Silva",
+          },
+        },
+      })),
+    },
+  }
+
   return (
     <div className="animate-fade-in-up">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       {/* Terminal Window Header */}
       <div className="border border-gray-800/60 bg-[#161616] mb-8">
         {/* Terminal Bar */}


### PR DESCRIPTION
JSON-LD Structured Data:
- Add src/lib/json-ld.tsx with reusable schema components
- Add Person + WebSite schema to root layout (global)
- Add ProfilePage schema to homepage
- Add Blog schema with BlogPosting items to /blog
- Add CollectionPage + ItemList with SoftwareSourceCode to /projects
- Add AboutPage with Person, worksFor, hasOccupation to /sobre
- Add CollectionPage + ItemList with Event schema to /talks

RSS Feed:
- Create src/app/feed.xml/route.ts for dynamic RSS 2.0 generation
- Include all blog posts with pubDate, author, description
- Add Atom self-reference link for compatibility
- Add image and category elements
- Set Cache-Control header (1 hour TTL)
- Add alternates.types to layout metadata for autodiscovery

Schemas implemented:
- Person, WebSite, ProfilePage, Blog, BlogPosting
- CollectionPage, ItemList, SoftwareSourceCode, Event
- AboutPage, Organization, Occupation