### PR TITLE
feat(a11y+ux): add skip links and terminal-themed loading skeletons

### DIFF
--- a/src/app/blog/[slug]/loading.tsx
+++ b/src/app/blog/[slug]/loading.tsx
@@ -1,0 +1,84 @@
+import {
+  TerminalSkeleton,
+  CommandLineSkeleton,
+  CodeBlockSkeleton,
+  BadgeSkeleton,
+} from "@/components/skeleton"
+
+export default function BlogPostLoading() {
+  return (
+    <article className="max-w-3xl mx-auto animate-fade-in">
+      {/* Terminal Header - Post Meta */}
+      <TerminalSkeleton title="~/blog/loading..." className="mb-8">
+        <div className="p-6">
+          {/* Title */}
+          <div className="w-3/4 h-10 bg-gray-800/40 rounded animate-pulse mb-6" />
+
+          {/* Metadata Line */}
+          <div className="flex flex-wrap items-center gap-4 mb-6 font-mono text-xs">
+            <div className="flex items-center gap-1.5">
+              <span className="w-3.5 h-3.5 bg-gray-800/40 rounded animate-pulse" />
+              <div className="w-24 h-3 bg-gray-800/40 rounded animate-pulse" />
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="w-3.5 h-3.5 bg-gray-800/40 rounded animate-pulse" />
+              <div className="w-20 h-3 bg-gray-800/40 rounded animate-pulse" />
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="w-3.5 h-3.5 bg-gray-800/40 rounded animate-pulse" />
+              <div className="w-16 h-3 bg-gray-800/40 rounded animate-pulse" />
+            </div>
+          </div>
+
+          {/* Tags */}
+          <div className="flex flex-wrap gap-2">
+            <BadgeSkeleton width="w-16" />
+            <BadgeSkeleton width="w-20" />
+            <BadgeSkeleton width="w-14" />
+          </div>
+        </div>
+      </TerminalSkeleton>
+
+      {/* Content Terminal */}
+      <TerminalSkeleton title="article.mdx">
+        <div className="p-8 space-y-8">
+          {/* First Paragraph */}
+          <div>
+            <CommandLineSkeleton command="reading content..." showCursor={false} />
+            <div className="mt-4">
+              <CodeBlockSkeleton lines={3} />
+            </div>
+          </div>
+
+          {/* Code Block */}
+          <div className="bg-[#1a1a1a] border border-gray-800/40 p-4">
+            <div className="flex items-center gap-2 mb-3 text-xs">
+              <span className="text-gray-600 font-mono">// code example</span>
+            </div>
+            <div className="space-y-2 pl-4 border-l border-gray-700/30">
+              <div className="w-64 h-3 bg-blue-400/10 rounded animate-pulse" />
+              <div className="w-56 h-3 bg-emerald-400/10 rounded animate-pulse" />
+              <div className="w-72 h-3 bg-gray-800/30 rounded animate-pulse" />
+              <div className="w-48 h-3 bg-gray-800/30 rounded animate-pulse" />
+            </div>
+          </div>
+
+          {/* Second Paragraph */}
+          <CodeBlockSkeleton lines={4} />
+
+          {/* Another Code Block */}
+          <div className="bg-[#1a1a1a] border border-gray-800/40 p-4">
+            <div className="space-y-2 pl-4 border-l border-gray-700/30">
+              <div className="w-72 h-3 bg-gray-800/30 rounded animate-pulse" />
+              <div className="w-56 h-3 bg-yellow-400/10 rounded animate-pulse" />
+              <div className="w-64 h-3 bg-gray-800/30 rounded animate-pulse" />
+            </div>
+          </div>
+
+          {/* Final Paragraph */}
+          <CodeBlockSkeleton lines={2} />
+        </div>
+      </TerminalSkeleton>
+    </article>
+  )
+}

--- a/src/app/blog/loading.tsx
+++ b/src/app/blog/loading.tsx
@@ -1,0 +1,48 @@
+import {
+  TerminalSkeleton,
+  CommandLineSkeleton,
+  CodeBlockSkeleton,
+  PostCardSkeleton,
+} from "@/components/skeleton"
+
+export default function BlogLoading() {
+  return (
+    <main className="animate-fade-in">
+      {/* Terminal Window Header */}
+      <TerminalSkeleton title="~/blog" className="mb-8">
+        <div className="p-6">
+          {/* Title skeleton */}
+          <div className="w-32 h-10 bg-gray-800/40 rounded animate-pulse mb-4" />
+
+          {/* Command Line */}
+          <div className="mb-4">
+            <CommandLineSkeleton command="cat description.md" showCursor={false} />
+          </div>
+
+          <CodeBlockSkeleton lines={2} />
+        </div>
+      </TerminalSkeleton>
+
+      {/* Keyboard Shortcuts Skeleton */}
+      <div className="hidden sm:flex items-center gap-6 mb-8 p-4 border border-gray-800/60 bg-[#161616]">
+        <div className="flex items-center gap-2">
+          <div className="w-3 h-3 bg-gray-800/40 rounded animate-pulse" />
+          <span className="text-gray-600 text-xs">Atalhos:</span>
+        </div>
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="flex items-center gap-2">
+            <kbd className="w-6 h-5 bg-gray-800/30 border border-gray-700/30 rounded" />
+            <div className="w-12 h-3 bg-gray-800/40 rounded animate-pulse" />
+          </div>
+        ))}
+      </div>
+
+      {/* Posts List */}
+      <div className="space-y-4">
+        {[0, 1, 2, 3, 4].map((i) => (
+          <PostCardSkeleton key={i} index={i} />
+        ))}
+      </div>
+    </main>
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next"
 import { Geist_Mono } from "next/font/google"
 import "./globals.css"
 import Transition from "@/components/transition"
+import { SkipLink } from "@/components/skip-link"
 
 const geistMono = Geist_Mono({
   subsets: ["latin"],
@@ -109,9 +110,10 @@ export default function RootLayout({
       <body
         className={`${geistMono.variable} antialiased min-h-screen font-mono overflow-x-hidden`}
       >
-        <div className="max-w-7xl mx-auto px-4 py-8 overflow-hidden md:overflow-visible">
+        <SkipLink />
+        <main id="main-content" className="max-w-7xl mx-auto px-4 py-8 overflow-hidden md:overflow-visible">
           <Transition>{children}</Transition>
-        </div>
+        </main>
       </body>
     </html>
   )

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,17 @@
+import {
+  NavbarSkeleton,
+  HeaderSkeleton,
+  BlogSectionSkeleton,
+  ProjectsSectionSkeleton,
+} from "@/components/skeleton"
+
+export default function HomeLoading() {
+  return (
+    <div className="animate-fade-in">
+      <NavbarSkeleton />
+      <HeaderSkeleton />
+      <BlogSectionSkeleton />
+      <ProjectsSectionSkeleton />
+    </div>
+  )
+}

--- a/src/app/presentations/[slug]/loading.tsx
+++ b/src/app/presentations/[slug]/loading.tsx
@@ -1,0 +1,5 @@
+import { PresentationSkeleton } from "@/components/skeleton"
+
+export default function PresentationLoading() {
+  return <PresentationSkeleton />
+}

--- a/src/app/projects/loading.tsx
+++ b/src/app/projects/loading.tsx
@@ -1,0 +1,56 @@
+import {
+  TerminalSkeleton,
+  CommandLineSkeleton,
+  CodeBlockSkeleton,
+  ProjectCardSkeleton,
+} from "@/components/skeleton"
+
+export default function ProjectsLoading() {
+  return (
+    <div className="animate-fade-in">
+      {/* Terminal Window - Header */}
+      <TerminalSkeleton title="~/projects" className="mb-8">
+        <div className="p-6">
+          {/* Title */}
+          <div className="w-48 h-10 bg-gray-800/40 rounded animate-pulse mb-4" />
+
+          {/* Command Line */}
+          <CommandLineSkeleton command="cat README.md" showCursor={false} />
+          <div className="mt-3">
+            <CodeBlockSkeleton lines={2} />
+          </div>
+        </div>
+      </TerminalSkeleton>
+
+      {/* Featured Project Section */}
+      <section className="mb-12">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="w-5 h-5 bg-blue-400/20 rounded animate-pulse" />
+          <div className="flex items-center gap-2 font-mono text-sm">
+            <span className="text-emerald-400/50">❯</span>
+            <span className="text-gray-600">ls --featured</span>
+          </div>
+        </div>
+
+        <ProjectCardSkeleton featured />
+      </section>
+
+      {/* All Projects Section */}
+      <section>
+        <div className="flex items-center gap-3 mb-6">
+          <div className="w-5 h-5 bg-gray-800/40 rounded animate-pulse" />
+          <div className="flex items-center gap-2 font-mono text-sm">
+            <span className="text-emerald-400/50">❯</span>
+            <span className="text-gray-600">ls -la</span>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {[1, 2, 3, 4].map((i) => (
+            <ProjectCardSkeleton key={i} />
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/sobre/loading.tsx
+++ b/src/app/sobre/loading.tsx
@@ -1,0 +1,54 @@
+import {
+  TerminalSkeleton,
+  CommandLineSkeleton,
+  CodeBlockSkeleton,
+  WorkItemSkeleton,
+  SkillsJsonSkeleton,
+} from "@/components/skeleton"
+
+export default function SobreLoading() {
+  return (
+    <div className="animate-fade-in">
+      {/* Terminal Window - About Header */}
+      <TerminalSkeleton title="~/sobre" className="mb-8">
+        <div className="p-6">
+          {/* Title */}
+          <div className="w-40 h-10 bg-gray-800/40 rounded animate-pulse mb-6" />
+
+          {/* Command Line Bio */}
+          <div className="font-mono text-sm space-y-3">
+            <CommandLineSkeleton command="whoami" showCursor={false} />
+            <div className="pl-5">
+              <div className="w-48 h-4 bg-gray-800/40 rounded animate-pulse" />
+            </div>
+
+            <div className="mt-4">
+              <CommandLineSkeleton command="cat bio.md" showCursor={false} />
+            </div>
+            <CodeBlockSkeleton lines={3} />
+          </div>
+        </div>
+      </TerminalSkeleton>
+
+      {/* Skills Grid */}
+      <SkillsJsonSkeleton />
+
+      {/* Work Experience Section */}
+      <section className="mt-10">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="w-5 h-5 bg-gray-800/40 rounded animate-pulse" />
+          <div className="flex items-center gap-2 font-mono text-sm">
+            <span className="text-emerald-400/50">❯</span>
+            <span className="text-gray-600">ls ~/experience</span>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          {[0, 1, 2].map((i) => (
+            <WorkItemSkeleton key={i} index={i} />
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/talks/loading.tsx
+++ b/src/app/talks/loading.tsx
@@ -1,0 +1,61 @@
+import {
+  TerminalSkeleton,
+  CommandLineSkeleton,
+  CodeBlockSkeleton,
+  TalkCardSkeleton,
+} from "@/components/skeleton"
+
+export default function TalksLoading() {
+  return (
+    <div className="animate-fade-in">
+      {/* Terminal Window - Header */}
+      <TerminalSkeleton title="~/talks" className="mb-8">
+        <div className="p-6">
+          {/* Title */}
+          <div className="w-64 h-10 bg-gray-800/40 rounded animate-pulse mb-4" />
+
+          {/* Command Line */}
+          <CommandLineSkeleton command="cat description.md" showCursor={false} />
+          <div className="mt-3">
+            <CodeBlockSkeleton lines={2} />
+          </div>
+        </div>
+      </TerminalSkeleton>
+
+      {/* Upcoming Section */}
+      <section className="mb-10">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="w-5 h-5 bg-emerald-400/20 rounded animate-pulse" />
+          <div className="flex items-center gap-2 font-mono text-sm">
+            <span className="text-emerald-400/50">❯</span>
+            <span className="text-gray-600">ls --upcoming</span>
+          </div>
+        </div>
+
+        <div className="bg-[#161616]/50 border border-dashed border-gray-700 p-8 text-center">
+          <div className="flex items-center justify-center gap-2 font-mono text-sm">
+            <span className="text-gray-600">//</span>
+            <div className="w-56 h-4 bg-gray-800/40 rounded animate-pulse" />
+          </div>
+        </div>
+      </section>
+
+      {/* Past Talks Section */}
+      <section>
+        <div className="flex items-center gap-3 mb-6">
+          <div className="w-5 h-5 bg-gray-800/40 rounded animate-pulse" />
+          <div className="flex items-center gap-2 font-mono text-sm">
+            <span className="text-emerald-400/50">❯</span>
+            <span className="text-gray-600">ls --past</span>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          {[0, 1, 2].map((i) => (
+            <TalkCardSkeleton key={i} index={i} />
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/components/skeleton.tsx
+++ b/src/components/skeleton.tsx
@@ -1,0 +1,547 @@
+/**
+ * Skeleton Components - Terminal Theme
+ * 100% harmonizado com a estética do site joaquimsnjr.tech
+ */
+
+// ============================================
+// BASE COMPONENTS
+// ============================================
+
+/**
+ * Terminal Window Container - Base para todos os skeletons
+ */
+export function TerminalSkeleton({
+  title = "loading...",
+  children,
+  className = "",
+}: {
+  title?: string
+  children: React.ReactNode
+  className?: string
+}) {
+  return (
+    <div className={`border border-gray-800/60 bg-[#161616] overflow-hidden ${className}`}>
+      {/* Terminal Header Bar */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-800/60 bg-[#1a1a1a]">
+        <div className="flex items-center gap-2">
+          <div className="flex gap-1.5">
+            <span className="w-3 h-3 rounded-full bg-red-500/40" />
+            <span className="w-3 h-3 rounded-full bg-yellow-500/40" />
+            <span className="w-3 h-3 rounded-full bg-green-500/40" />
+          </div>
+          <span className="ml-3 text-xs text-gray-600 font-mono">{title}</span>
+        </div>
+        <div className="flex items-center gap-1 text-gray-700">
+          <span className="w-1 h-3 bg-gray-700 animate-pulse" />
+        </div>
+      </div>
+      {children}
+    </div>
+  )
+}
+
+/**
+ * Linha de comando skeleton
+ */
+export function CommandLineSkeleton({
+  command = "loading",
+  showCursor = true,
+}: {
+  command?: string
+  showCursor?: boolean
+}) {
+  return (
+    <div className="flex items-center gap-2 font-mono text-sm">
+      <span className="text-emerald-400/50 select-none">❯</span>
+      <span className="text-gray-600">{command}</span>
+      {showCursor && (
+        <span className="w-2 h-4 bg-gray-600 animate-pulse" />
+      )}
+    </div>
+  )
+}
+
+/**
+ * Bloco de texto skeleton com estilo code
+ */
+export function CodeBlockSkeleton({ lines = 3 }: { lines?: number }) {
+  const widths = ["w-3/4", "w-full", "w-5/6", "w-2/3", "w-4/5", "w-1/2"]
+
+  return (
+    <div className="pl-5 border-l-2 border-gray-800/60 space-y-2">
+      {Array.from({ length: lines }).map((_, i) => (
+        <div
+          key={i}
+          className={`h-4 bg-gray-800/40 rounded ${widths[i % widths.length]} animate-pulse`}
+          style={{ animationDelay: `${i * 100}ms` }}
+        />
+      ))}
+    </div>
+  )
+}
+
+/**
+ * Badge/Tag skeleton
+ */
+export function BadgeSkeleton({ width = "w-16" }: { width?: string }) {
+  return (
+    <span className={`h-5 ${width} bg-gray-800/40 rounded animate-pulse`} />
+  )
+}
+
+/**
+ * Status indicator skeleton
+ */
+export function StatusSkeleton() {
+  return (
+    <div className="flex items-center gap-2 border border-gray-700/30 px-3 py-1">
+      <span className="w-2 h-2 rounded-full bg-gray-700 animate-pulse" />
+      <span className="w-12 h-3 bg-gray-800/40 rounded animate-pulse" />
+    </div>
+  )
+}
+
+// ============================================
+// NAVBAR SKELETON
+// ============================================
+
+export function NavbarSkeleton() {
+  return (
+    <nav className="flex items-center justify-between py-4 mb-8 border-b border-gray-800/40">
+      {/* Logo */}
+      <div className="flex items-center gap-2">
+        <span className="text-gray-700 font-mono">❯</span>
+        <div className="w-32 h-5 bg-gray-800/40 rounded animate-pulse" />
+      </div>
+
+      {/* Nav Items */}
+      <div className="hidden sm:flex items-center gap-6">
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} className="flex items-center gap-2">
+            <kbd className="w-6 h-5 bg-gray-800/30 border border-gray-700/30 rounded text-[10px]" />
+            <div className="w-12 h-4 bg-gray-800/40 rounded animate-pulse" />
+          </div>
+        ))}
+      </div>
+    </nav>
+  )
+}
+
+// ============================================
+// HEADER SKELETON (Homepage)
+// ============================================
+
+export function HeaderSkeleton() {
+  return (
+    <TerminalSkeleton title="~/Development/joaquimsnjr.tech — zsh" className="mb-16">
+      <div className="p-6 md:p-8">
+        {/* Profile Section */}
+        <div className="flex flex-col sm:flex-row gap-6 items-start">
+          {/* Avatar */}
+          <div className="relative">
+            <div className="w-[100px] h-[100px] rounded-full bg-gray-800/60 animate-pulse border-2 border-gray-800" />
+            <span className="absolute bottom-1 right-1 w-4 h-4 bg-gray-700 rounded-full border-2 border-[#161616] animate-pulse" />
+          </div>
+
+          {/* Info */}
+          <div className="flex-1 space-y-4">
+            {/* Name */}
+            <div>
+              <div className="w-48 h-8 bg-gray-800/40 rounded animate-pulse mb-2" />
+              <div className="flex items-center gap-2 font-mono text-sm">
+                <span className="text-blue-400/50">const</span>
+                <span className="text-gray-600">role =</span>
+                <div className="w-40 h-4 bg-gray-800/40 rounded animate-pulse" />
+              </div>
+            </div>
+
+            {/* Location & Status */}
+            <div className="flex flex-wrap items-center gap-4 text-sm text-gray-600">
+              <div className="flex items-center gap-1.5">
+                <span className="w-4 h-4 bg-gray-800/40 rounded animate-pulse" />
+                <div className="w-28 h-4 bg-gray-800/40 rounded animate-pulse" />
+              </div>
+              <div className="flex items-center gap-1.5">
+                <span className="w-4 h-4 bg-gray-800/40 rounded animate-pulse" />
+                <div className="w-36 h-4 bg-gray-800/40 rounded animate-pulse" />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Divider */}
+        <div className="my-6 border-t border-dashed border-gray-800/60" />
+
+        {/* Command Line Bio */}
+        <div className="font-mono text-sm space-y-3">
+          <CommandLineSkeleton command="cat about.md" showCursor={false} />
+          <CodeBlockSkeleton lines={2} />
+        </div>
+      </div>
+    </TerminalSkeleton>
+  )
+}
+
+// ============================================
+// BLOG POST CARD SKELETON
+// ============================================
+
+export function PostCardSkeleton({ index = 0 }: { index?: number }) {
+  return (
+    <div
+      className="border border-gray-800/60 bg-[#161616] p-5 group"
+      style={{ animationDelay: `${index * 50}ms` }}
+    >
+      {/* Command prompt */}
+      <div className="flex items-center gap-2 mb-4 font-mono text-xs">
+        <span className="text-emerald-400/50">❯</span>
+        <span className="text-gray-600">cat</span>
+        <div className="w-32 h-3 bg-gray-800/40 rounded animate-pulse" />
+      </div>
+
+      {/* Title */}
+      <div className="w-4/5 h-5 bg-gray-800/40 rounded animate-pulse mb-3" />
+
+      {/* Description */}
+      <div className="space-y-2 mb-4">
+        <div className="w-full h-3 bg-gray-800/30 rounded animate-pulse" />
+        <div className="w-5/6 h-3 bg-gray-800/30 rounded animate-pulse" />
+      </div>
+
+      {/* Meta */}
+      <div className="flex items-center gap-4 text-xs">
+        <div className="flex items-center gap-1">
+          <span className="w-3 h-3 bg-gray-800/40 rounded animate-pulse" />
+          <div className="w-20 h-3 bg-gray-800/40 rounded animate-pulse" />
+        </div>
+        <div className="flex items-center gap-1">
+          <span className="w-3 h-3 bg-gray-800/40 rounded animate-pulse" />
+          <div className="w-16 h-3 bg-gray-800/40 rounded animate-pulse" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ============================================
+// PROJECT CARD SKELETON
+// ============================================
+
+export function ProjectCardSkeleton({ featured = false }: { featured?: boolean }) {
+  return (
+    <div className={`border border-gray-800/60 bg-[#161616] ${featured ? "" : ""}`}>
+      {/* Terminal Header */}
+      <div className="flex items-center justify-between px-5 py-3 border-b border-gray-800/60 bg-[#1a1a1a]">
+        <div className="flex items-center gap-4">
+          <div className="flex gap-1.5">
+            <span className="w-3 h-3 rounded-full bg-red-500/40" />
+            <span className="w-3 h-3 rounded-full bg-yellow-500/40" />
+            <span className="w-3 h-3 rounded-full bg-green-500/40" />
+          </div>
+          <div className="w-40 h-3 bg-gray-800/40 rounded animate-pulse font-mono" />
+        </div>
+        <StatusSkeleton />
+      </div>
+
+      {/* Content */}
+      <div className={`p-6 ${featured ? "lg:grid lg:grid-cols-2 lg:gap-6" : ""}`}>
+        {/* Info */}
+        <div>
+          <div className="mb-4 flex items-center gap-4">
+            {/* Icon */}
+            <div className="flex h-14 w-14 items-center justify-center border border-gray-700/30 bg-gray-800/20">
+              <div className="w-7 h-7 bg-gray-800/40 rounded animate-pulse" />
+            </div>
+            <div className="flex-1">
+              <div className="w-40 h-5 bg-gray-800/40 rounded animate-pulse mb-2" />
+              <div className="w-24 h-3 bg-gray-800/30 rounded animate-pulse" />
+            </div>
+          </div>
+
+          {/* Description */}
+          <div className="mb-5 border-l-2 border-gray-700/30 pl-4 space-y-2">
+            <div className="w-full h-4 bg-gray-800/30 rounded animate-pulse" />
+            <div className="w-4/5 h-4 bg-gray-800/30 rounded animate-pulse" />
+          </div>
+
+          {/* Links */}
+          <div className="flex items-center gap-5">
+            <div className="w-24 h-4 bg-gray-800/30 rounded animate-pulse" />
+            <div className="w-20 h-4 bg-gray-800/30 rounded animate-pulse" />
+          </div>
+        </div>
+
+        {/* Stack (featured only) */}
+        {featured && (
+          <div className="mt-6 lg:mt-0 border-t lg:border-t-0 lg:border-l border-gray-800/40 pt-6 lg:pt-0 lg:pl-6">
+            <div className="w-24 h-4 bg-gray-800/40 rounded animate-pulse mb-4" />
+            <div className="flex flex-wrap gap-2">
+              {[1, 2, 3, 4, 5].map((i) => (
+                <div
+                  key={i}
+                  className="px-3 py-1.5 bg-gray-800/20 border border-gray-700/30 rounded"
+                >
+                  <div className="w-16 h-3 bg-gray-800/40 rounded animate-pulse" />
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ============================================
+// TALK CARD SKELETON
+// ============================================
+
+export function TalkCardSkeleton({ index = 0 }: { index?: number }) {
+  return (
+    <div
+      className="border border-gray-800/60 bg-[#161616]"
+      style={{ animationDelay: `${index * 100}ms` }}
+    >
+      {/* Terminal Header */}
+      <div className="flex items-center justify-between px-4 py-2 border-b border-gray-800/40 bg-[#1a1a1a]">
+        <div className="flex items-center gap-2">
+          <div className="flex gap-1">
+            <span className="w-2 h-2 rounded-full bg-red-500/40" />
+            <span className="w-2 h-2 rounded-full bg-yellow-500/40" />
+            <span className="w-2 h-2 rounded-full bg-green-500/40" />
+          </div>
+          <span className="text-[10px] text-gray-600 font-mono ml-2">talks/{index + 1}</span>
+        </div>
+        <BadgeSkeleton width="w-16" />
+      </div>
+
+      {/* Content */}
+      <div className="p-5">
+        {/* Title & Icon */}
+        <div className="flex items-start gap-3 mb-4">
+          <div className="flex h-10 w-10 items-center justify-center border border-gray-700/30 bg-gray-800/20">
+            <div className="w-5 h-5 bg-gray-800/40 rounded animate-pulse" />
+          </div>
+          <div className="flex-1">
+            <div className="w-3/4 h-5 bg-gray-800/40 rounded animate-pulse mb-2" />
+            <div className="w-1/3 h-3 bg-blue-400/20 rounded animate-pulse" />
+          </div>
+        </div>
+
+        {/* Meta */}
+        <div className="flex flex-wrap items-center gap-4 text-xs mb-4">
+          <div className="flex items-center gap-1.5">
+            <span className="w-3.5 h-3.5 bg-gray-800/40 rounded animate-pulse" />
+            <div className="w-24 h-3 bg-gray-800/40 rounded animate-pulse" />
+          </div>
+          <div className="flex items-center gap-1.5">
+            <span className="w-3.5 h-3.5 bg-gray-800/40 rounded animate-pulse" />
+            <div className="w-20 h-3 bg-gray-800/40 rounded animate-pulse" />
+          </div>
+        </div>
+
+        {/* Description */}
+        <div className="border-l-2 border-gray-700/50 pl-3">
+          <div className="flex items-start gap-2">
+            <span className="text-gray-700 text-sm">//</span>
+            <div className="flex-1 space-y-2">
+              <div className="w-full h-3 bg-gray-800/30 rounded animate-pulse" />
+              <div className="w-4/5 h-3 bg-gray-800/30 rounded animate-pulse" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ============================================
+// WORK EXPERIENCE SKELETON
+// ============================================
+
+export function WorkItemSkeleton({ index = 0 }: { index?: number }) {
+  return (
+    <div
+      className="border border-gray-800/60 bg-[#161616] p-5"
+      style={{ animationDelay: `${index * 100}ms` }}
+    >
+      <div className="flex items-start justify-between mb-3">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center border border-gray-700/30 bg-gray-800/20">
+            <div className="w-5 h-5 bg-gray-800/40 rounded animate-pulse" />
+          </div>
+          <div>
+            <div className="w-36 h-5 bg-gray-800/40 rounded animate-pulse mb-2" />
+            <div className="w-28 h-3 bg-blue-400/20 rounded animate-pulse" />
+          </div>
+        </div>
+        <div className="w-24 h-4 bg-gray-800/30 rounded animate-pulse" />
+      </div>
+
+      <div className="border-l-2 border-gray-700/50 pl-4 mt-4 space-y-2">
+        <div className="w-full h-3 bg-gray-800/30 rounded animate-pulse" />
+        <div className="w-5/6 h-3 bg-gray-800/30 rounded animate-pulse" />
+        <div className="w-4/5 h-3 bg-gray-800/30 rounded animate-pulse" />
+      </div>
+
+      {/* Technologies */}
+      <div className="flex flex-wrap gap-2 mt-4">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="px-2 py-1 bg-gray-800/20 border border-gray-700/30 rounded">
+            <div className="w-12 h-3 bg-gray-800/40 rounded animate-pulse" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ============================================
+// SKILLS JSON SKELETON
+// ============================================
+
+export function SkillsJsonSkeleton() {
+  return (
+    <TerminalSkeleton title="skills.json">
+      <div className="p-5 font-mono text-sm">
+        <p className="text-gray-600">{"{"}</p>
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} className="ml-4 my-3" style={{ animationDelay: `${i * 100}ms` }}>
+            <div className="flex items-center gap-2">
+              <div className="w-24 h-4 bg-blue-400/20 rounded animate-pulse" />
+              <span className="text-gray-600">:</span>
+              <span className="text-gray-700">[</span>
+            </div>
+            <div className="ml-4 flex flex-wrap gap-2 my-2">
+              {[1, 2, 3].map((j) => (
+                <div key={j} className="w-16 h-4 bg-emerald-400/10 rounded animate-pulse" />
+              ))}
+            </div>
+            <span className="ml-4 text-gray-700">]</span>
+            {i < 4 && <span className="text-gray-600">,</span>}
+          </div>
+        ))}
+        <p className="text-gray-600">{"}"}</p>
+      </div>
+    </TerminalSkeleton>
+  )
+}
+
+// ============================================
+// BLOG SECTION SKELETON (Homepage)
+// ============================================
+
+export function BlogSectionSkeleton() {
+  return (
+    <section className="my-16">
+      {/* Section Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <CommandLineSkeleton command="ls ~/blog" showCursor={false} />
+        </div>
+        <div className="w-20 h-4 bg-gray-800/30 rounded animate-pulse" />
+      </div>
+
+      {/* Bento Grid */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {/* Featured Post */}
+        <div className="md:col-span-2 lg:col-span-2">
+          <TerminalSkeleton title="featured.md" className="h-full">
+            <div className="p-6">
+              <div className="w-3/4 h-7 bg-gray-800/40 rounded animate-pulse mb-4" />
+              <div className="space-y-2 mb-6">
+                <div className="w-full h-4 bg-gray-800/30 rounded animate-pulse" />
+                <div className="w-5/6 h-4 bg-gray-800/30 rounded animate-pulse" />
+                <div className="w-4/5 h-4 bg-gray-800/30 rounded animate-pulse" />
+              </div>
+              <div className="flex items-center gap-4">
+                <div className="w-24 h-4 bg-gray-800/30 rounded animate-pulse" />
+                <div className="w-20 h-4 bg-gray-800/30 rounded animate-pulse" />
+              </div>
+            </div>
+          </TerminalSkeleton>
+        </div>
+
+        {/* Regular Posts */}
+        {[1, 2, 3].map((i) => (
+          <PostCardSkeleton key={i} index={i} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+// ============================================
+// PROJECTS SECTION SKELETON (Homepage)
+// ============================================
+
+export function ProjectsSectionSkeleton() {
+  return (
+    <section className="my-16">
+      {/* Section Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <CommandLineSkeleton command="ls ~/projects" showCursor={false} />
+        </div>
+        <div className="w-24 h-4 bg-gray-800/30 rounded animate-pulse" />
+      </div>
+
+      {/* Projects Grid */}
+      <div className="space-y-6">
+        <ProjectCardSkeleton featured />
+      </div>
+    </section>
+  )
+}
+
+// ============================================
+// PRESENTATION LOADING SKELETON
+// ============================================
+
+export function PresentationSkeleton() {
+  return (
+    <div className="fixed inset-0 bg-[#111] flex items-center justify-center">
+      <TerminalSkeleton title="presentation — loading" className="w-96">
+        <div className="p-6 font-mono text-sm">
+          {/* Loading indicator */}
+          <div className="flex items-center gap-2 text-gray-400 mb-6">
+            <span className="text-blue-400">❯</span>
+            <span className="text-gray-500">initializing deck...</span>
+            <span className="w-2 h-4 bg-blue-400 animate-pulse" />
+          </div>
+
+          {/* Progress steps */}
+          <div className="space-y-3">
+            <div className="flex items-center gap-3">
+              <span className="w-4 h-4 border border-green-400/50 text-green-400 flex items-center justify-center text-xs">✓</span>
+              <span className="text-gray-400">Loading assets</span>
+            </div>
+            <div className="flex items-center gap-3">
+              <span className="w-4 h-4 border border-green-400/50 text-green-400 flex items-center justify-center text-xs">✓</span>
+              <span className="text-gray-400">Parsing slides</span>
+            </div>
+            <div className="flex items-center gap-3">
+              <span className="w-4 h-4 border border-yellow-400/50 animate-pulse" />
+              <span className="text-gray-400">Rendering components</span>
+            </div>
+            <div className="flex items-center gap-3">
+              <span className="w-4 h-4 border border-gray-700" />
+              <span className="text-gray-600">Starting presentation</span>
+            </div>
+          </div>
+
+          {/* Progress bar */}
+          <div className="mt-6 pt-4 border-t border-gray-800/60">
+            <div className="flex items-center justify-between text-xs text-gray-500 mb-2">
+              <span>Progress</span>
+              <span className="font-mono">75%</span>
+            </div>
+            <div className="h-1 bg-gray-800 rounded-full overflow-hidden">
+              <div className="h-full w-3/4 bg-blue-400 rounded-full animate-pulse" />
+            </div>
+          </div>
+        </div>
+      </TerminalSkeleton>
+    </div>
+  )
+}

--- a/src/components/skip-link.tsx
+++ b/src/components/skip-link.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import Link from "next/link"
+
+/**
+ * SkipLink - Componente de acessibilidade para pular navegação.
+ * Visível apenas quando focado via teclado (Tab).
+ */
+export function SkipLink() {
+  return (
+    <Link
+      href="#main-content"
+      className="
+        sr-only focus:not-sr-only
+        focus:fixed focus:top-4 focus:left-4 focus:z-[100]
+        focus:px-4 focus:py-2
+        focus:bg-blue-500 focus:text-white
+        focus:border focus:border-blue-400
+        focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-[#111]
+        font-mono text-sm
+        transition-all duration-200
+      "
+    >
+      Pular para o conteúdo principal
+    </Link>
+  )
+}


### PR DESCRIPTION
Accessibility - Skip Links:
- Create src/components/skip-link.tsx for keyboard navigation
- Add skip link to layout.tsx (sr-only, visible on focus)
- Change container from <div> to <main id='main-content'>

Loading States - Terminal-Themed Skeletons:
- Create src/components/skeleton.tsx with reusable components:
  - TerminalSkeleton: Base container with macOS dots header
  - CommandLineSkeleton: Animated command prompt with cursor
  - CodeBlockSkeleton: Code block with line numbers
  - BadgeSkeleton, StatusSkeleton: Inline elements
  - NavbarSkeleton, HeaderSkeleton: Page structure
  - PostCardSkeleton, ProjectCardSkeleton, TalkCardSkeleton
  - BlogSectionSkeleton, ProjectsSectionSkeleton
  - SkillsJsonSkeleton, WorkItemSkeleton
  - PresentationSkeleton with progress steps

- Add loading.tsx for all routes:
  - / (homepage): Full page with header, blog, projects
  - /blog: Terminal header + post cards grid
  - /blog/[slug]: Article skeleton with MDX content
  - /projects: Featured + project cards grid
  - /sobre: Header, skills JSON, work experience
  - /talks: Terminal header + talk cards
  - /presentations/[slug]: Deck loading with progress

Design consistency:
- macOS dots (red/yellow/green) with 40% opacity
- Colors: bg-[#161616], bg-[#1a1a1a], border-gray-800/60
- Prompts: ❯ with emerald-400/50, keywords blue-400/50
- Staggered animations with animationDelay
- All using animate-pulse and animate-in fade-in