### PR TITLE
feat: add Edge Runtime APIs for views and OG images

### DIFF
--- a/src/app/api/views/[slug]/route.ts
+++ b/src/app/api/views/[slug]/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest } from "next/server"
+import { getViews, incrementViews } from "@/lib/redis"
+
+export const runtime = "edge"
+
+type RouteContext = {
+  params: Promise<{ slug: string }>
+}
+
+// GET /api/views/[slug] - Get view count
+export async function GET(
+  request: NextRequest,
+  context: RouteContext
+) {
+  try {
+    const { slug } = await context.params
+    const views = await getViews(slug)
+
+    return Response.json(
+      { views },
+      {
+        headers: {
+          "Cache-Control": "public, s-maxage=60, stale-while-revalidate=30",
+        },
+      }
+    )
+  } catch (error) {
+    console.error("Error fetching views:", error)
+    return Response.json({ views: 0 }, { status: 500 })
+  }
+}
+
+// POST /api/views/[slug] - Increment view count
+export async function POST(
+  request: NextRequest,
+  context: RouteContext
+) {
+  try {
+    const { slug } = await context.params
+    const views = await incrementViews(slug)
+
+    return Response.json({ views })
+  } catch (error) {
+    console.error("Error incrementing views:", error)
+    return Response.json({ error: "Failed to increment views" }, { status: 500 })
+  }
+}

--- a/src/app/og/blog/route.tsx
+++ b/src/app/og/blog/route.tsx
@@ -1,5 +1,7 @@
 import { ImageResponse } from "next/og"
 
+export const runtime = "edge"
+
 async function loadGoogleFont(fontName: string, text: string) {
   const url = `https://fonts.googleapis.com/css2?family=${fontName.replace(/ /g, "+")}&text=${encodeURIComponent(text)}`
   const css = await (await fetch(url)).text()


### PR DESCRIPTION
- Add /api/views/[slug] API with Edge Runtime
- Configure Upstash Redis for edge-native storage
- Update og/blog route to use Edge Runtime
- Rewrite ViewCounter component to use API