### PR TITLE
Ajustar tamanho da foto e traduzir menu para português

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -8,8 +8,8 @@ export function Header() {
       <div className="grid gap-8 border-b border-[color:var(--border)] pb-10 md:grid-cols-[120px,1fr] md:items-start">
         <div className="relative h-24 w-24 overflow-hidden rounded-sm">
           <Image
-            width={96}
-            height={96}
+            width={90}
+            height={90}
             src="https://res.cloudinary.com/dy5xyare1/image/upload/v1775099930/Profile_black-white_dzgqsu.jpg"
             alt="Joaquim Silva - SRE & Software Engineer"
             className="h-full w-full object-cover"

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -44,7 +44,7 @@ export function Navbar() {
   const navItems = [
     { href: "/", label: "home", shortcut: "h" },
     { href: "/blog", label: "blog", shortcut: "b" },
-    { href: "/projects", label: "projects", shortcut: "p" },
+    { href: "/projects", label: "projetos", shortcut: "p" },
     { href: "/sobre", label: "sobre", shortcut: "s" },
     { href: "/talks", label: "talks", shortcut: "t" },
   ]


### PR DESCRIPTION
## Changes
- Reduz a imagem de perfil de 96px para 90px no header da homepage
- Traduz o label "projects" para "projetos" na navegação

## Files changed
- `src/components/header.tsx`
- `src/components/navbar.tsx`

## Type
- refactor

## Breaking changes?
- Não