### PR TITLE
fix: corrige cor das listas nos posts para tema escuro (#A0A0A0)

### DIFF
--- a/src/app/blog/[slug]/loading.tsx
+++ b/src/app/blog/[slug]/loading.tsx
@@ -6,7 +6,7 @@ export default function BlogPostLoading() {
         Carregando...
       </h1>
       <p className="mt-4 text-sm text-[color:var(--muted)]">
-        Preparando conteudo.
+        Preparando conteúdo.
       </p>
     </section>
   )

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -170,6 +170,12 @@ body {
   border-color: var(--border);
 }
 
+/* Melhora legibilidade das listas de postagens */
+.prose li {
+  color: var(--muted);
+}
+/* fim do bloco de estilos para listas */
+
 .prose pre {
   @apply overflow-x-auto my-4 rounded-none;
   border: 1px solid var(--code-border);


### PR DESCRIPTION
## Descrição
Ajusta a cor do texto dos itens de lista (`<li>`) dentro dos posts para usar a variável `--muted`, garantindo melhor contraste e legibilidade no tema escuro.

## Mudanças
- Adiciona regra CSS `.prose li { color: var(--muted); }` em `globals.css`

## Por quê?
- No tema escuro, as listas estavam com uma cor inadequada
- A cor `#A0A0A0` (muted) oferece melhor contraste contra o fundo escuro

## Como testar
1. Ir para a página de um blog post
2. Verificar a aparência das listas no tema escuro
3. Confirmar que o texto está legível com a cor #A0A0A0